### PR TITLE
Initialize Phaser prototype with GitHub Pages workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_feature.md
+++ b/.github/ISSUE_TEMPLATE/01_feature.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Propose gameplay, UI, or content
+labels: feature
+---
+**Goal**
+Describe the outcome.
+
+**Details**
+- Why it matters
+- Acceptance criteria (checklist)
+
+**Notes**
+(Optional sketches, links)

--- a/.github/ISSUE_TEMPLATE/02_bug.md
+++ b/.github/ISSUE_TEMPLATE/02_bug.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Something broke or feels wrong
+labels: bug
+---
+**Steps to reproduce**
+1.
+2.
+3.
+
+**Expected**
+
+**Actual**
+
+**Build/Commit**
+
+**Notes**

--- a/.github/ISSUE_TEMPLATE/03_balance.md
+++ b/.github/ISSUE_TEMPLATE/03_balance.md
@@ -1,0 +1,10 @@
+---
+name: Balance note
+about: Tweak numbers/feel
+labels: balance
+---
+**Observation**
+
+**Change suggestion**
+
+**Playtest context**

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Build and Deploy (GitHub Pages)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-store
+
+# Build
+/dist
+/.vite
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Bedroom Monster (Proto)
+Top-down survival prototype built with Phaser + TypeScript. **GitHub-only workflow**: CI builds and deploys to GitHub Pages on every push to `main`.
+
+## Play it
+Enable GitHub Pages → Source: **GitHub Actions**. The Actions workflow in `.github/workflows/deploy.yml` deploys `dist/`.
+
+## Scripts
+- `npm run dev` – local dev (optional if using Codespaces)
+- `npm run build` – build to `dist/`
+- `npm run preview` – serve the build locally
+
+## Controls
+- Move: Arrow keys
+- Interact: `E` (pickup/swap), `G` (drop slot 1)
+- Use: `1` (slot 1), `2` (slot 2)
+- Craft: `R` (combine slots → result in slot 1)
+
+## Design targets
+- Player HP **5**, Monster HP **12**
+- Two-slot inventory; base items & a few recipes
+- Monster chase with simple periodic actions
+
+## Roadmap
+See Issues and Milestones.

--- a/file
+++ b/file
@@ -1,1 +1,0 @@
-new file

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bedroom Monster</title>
+  </head>
+  <body style="margin:0;background:#0b0d12;color:#e6e6e6">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bedroom-monster",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 5173"
+  },
+  "dependencies": {
+    "phaser": "^3.80.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.2",
+    "vite": "^5.4.3"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="8" fill="#222"/>
+  <path d="M3 11l5-6 5 6" stroke="#e6e6e6" stroke-width="1.5" fill="none"/>
+</svg>

--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -1,0 +1,5 @@
+export const ROOM_W = 1200;
+export const ROOM_H = 900;
+
+export const PLAYER_BASE = { hp: 5, maxHp: 5, speed: 200 } as const;
+export const MONSTER_BASE = { hp: 12, speed: 160 } as const; // slower than player; tuned in-scene

--- a/src/game/items.ts
+++ b/src/game/items.ts
@@ -1,0 +1,19 @@
+import type { Item, ItemId } from './types';
+
+export const BASE_ITEMS: Record<ItemId, Item> = {
+  match: { id: 'match', label: 'Match', uses: 2 },
+  knife: { id: 'knife', label: 'Pocket Knife', uses: 5 },
+  soda: { id: 'soda', label: 'Soda', uses: 2 },
+  bottle: { id: 'bottle', label: 'Empty Bottle', uses: 1 },
+  bandaid: { id: 'bandaid', label: 'Bandaid', uses: 1 },
+  yoyo: { id: 'yoyo', label: 'Yoyo', uses: 3 },
+
+  fire_bottle: { id: 'fire_bottle', label: 'Fire Bottle', uses: 1 },
+  bladed_yoyo: { id: 'bladed_yoyo', label: 'Bladed Yoyo', uses: 3 },
+  glass_shiv: { id: 'glass_shiv', label: 'Glass Shiv', uses: 2 },
+  smoke_patch: { id: 'smoke_patch', label: 'Smoke Patch', uses: 1 },
+  adrenal_patch: { id: 'adrenal_patch', label: 'Adrenal Patch', uses: 1 },
+  fizz_bomb: { id: 'fizz_bomb', label: 'Fizz Pop Bomb', uses: 1 },
+};
+
+export function cloneItem(id: ItemId): Item { const b = BASE_ITEMS[id]; return { ...b, data: { ...(b.data||{}) } }; }

--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -1,0 +1,63 @@
+import Phaser from 'phaser';
+import { ROOM_W, ROOM_H } from './config';
+
+export class Monster extends Phaser.Physics.Arcade.Sprite {
+  hp = 12;
+  state: 'wander'|'chase'|'engage' = 'wander';
+  actionT = { sweep: 2.5, smash: 4.0, rush: 5.0, roar: 7.0 };
+  cd = { sweep: 0, smash: 0, rush: 0, roar: 0 };
+  speed = 140;
+  target?: Phaser.Types.Physics.Arcade.GameObjectWithBody;
+
+  constructor(scene: Phaser.Scene, x: number, y: number) {
+    super(scene, x, y, '');
+    scene.add.existing(this);
+    scene.physics.add.existing(this);
+    this.setCircle(18).setOffset(0,0).setTint(0xff8844);
+  }
+
+  update(dt: number, player: Phaser.Physics.Arcade.Sprite) {
+    const d = Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y);
+    this.state = d > 300 ? 'wander' : d > 140 ? 'chase' : 'engage';
+
+    // cooldowns
+    for (const k in this.cd) (this.cd as any)[k] = Math.max(0, (this.cd as any)[k] - dt);
+
+    // simple steering
+    if (this.state === 'wander') {
+      this.scene.physics.moveToObject(this, player, this.speed * 0.6);
+    } else if (this.state === 'chase') {
+      this.scene.physics.moveToObject(this, player, this.speed * 1.0);
+    } else {
+      this.scene.physics.moveToObject(this, player, this.speed * 1.1);
+      // try an action (telegraph not yet visualized; placeholder effects)
+      if (this.cd.sweep === 0) { this.sweep(player); this.cd.sweep = this.actionT.sweep; }
+      else if (this.cd.smash === 0) { this.smash(player); this.cd.smash = this.actionT.smash; }
+      else if (this.cd.rush === 0) { this.rush(player); this.cd.rush = this.actionT.rush; }
+      else if (this.cd.roar === 0) { this.roar(player); this.cd.roar = this.actionT.roar; }
+    }
+  }
+
+  sweep(player: Phaser.Physics.Arcade.Sprite) {
+    // close cone check → knockback  
+    if (Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y) < 80) {
+      player.emit('hit', { dmg: 1, type: 'sweep' });
+    }
+  }
+  smash(player: Phaser.Physics.Arcade.Sprite) {
+    if (Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y) < 120) {
+      player.emit('hit', { dmg: 1, type: 'smash' });
+    }
+  }
+  rush(player: Phaser.Physics.Arcade.Sprite) {
+    // brief burst
+    const v = this.scene.physics.velocityFromRotation(
+      Phaser.Math.Angle.Between(this.x, this.y, player.x, player.y), 320);
+    this.setVelocity(v.x, v.y);
+  }
+  roar(player: Phaser.Physics.Arcade.Sprite) {
+    // slow effect placeholder
+    this.setTintFill(0xffaa66);
+    this.scene.time.delayedCall(200, () => this.clearTint());
+  }
+}

--- a/src/game/recipes.ts
+++ b/src/game/recipes.ts
@@ -1,0 +1,17 @@
+import type { ItemId } from './types';
+
+export type Recipe = { a: ItemId; b: ItemId; out: ItemId };
+
+export const RECIPES: Recipe[] = [
+  { a: 'bottle', b: 'match', out: 'fire_bottle' },
+  { a: 'yoyo',   b: 'knife', out: 'bladed_yoyo' },
+  { a: 'knife',  b: 'bottle', out: 'glass_shiv' },
+  { a: 'match',  b: 'bandaid', out: 'smoke_patch' },
+  { a: 'soda',   b: 'bandaid', out: 'adrenal_patch' },
+  { a: 'soda',   b: 'match', out: 'fizz_bomb' },
+];
+
+export function craft(a: ItemId, b: ItemId): ItemId | null {
+  const r = RECIPES.find(r => (r.a === a && r.b === b) || (r.a === b && r.b === a));
+  return r ? r.out : null;
+}

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,0 +1,16 @@
+export type ItemId =
+  | 'match' | 'knife' | 'soda' | 'bottle' | 'bandaid' | 'yoyo'
+  | 'fire_bottle' | 'bladed_yoyo' | 'glass_shiv' | 'smoke_patch' | 'adrenal_patch' | 'fizz_bomb';
+
+export type Item = {
+  id: ItemId;
+  label: string;
+  uses: number;
+  data?: Record<string, unknown>;
+};
+
+export type Inventory = [Item | null, Item | null];
+
+export type Stats = { hp: number; maxHp: number; speed: number };
+
+export type MonsterState = 'wander' | 'chase' | 'engage';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,16 @@
+import Phaser from 'phaser';
+import { PlayScene } from '@scenes/PlayScene';
+import { ROOM_W, ROOM_H } from '@game/config';
+
+const game = new Phaser.Game({
+  type: Phaser.AUTO,
+  width: ROOM_W,
+  height: ROOM_H,
+  backgroundColor: '#0b0d12',
+  parent: 'app',
+  physics: { default: 'arcade', arcade: { debug: false } },
+  scene: [PlayScene],
+});
+
+// Expose for simple debugging in console
+(window as any).game = game;

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -1,0 +1,216 @@
+import Phaser from 'phaser';
+import { ROOM_W, ROOM_H, PLAYER_BASE } from '@game/config';
+import type { Inventory, Item } from '@game/types';
+import { cloneItem } from '@game/items';
+import { craft } from '@game/recipes';
+import { Monster } from '@game/monster';
+import { drawHUD } from '@ui/hud';
+
+export class PlayScene extends Phaser.Scene {
+  player!: Phaser.Physics.Arcade.Sprite;
+  monster!: Monster;
+  cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+  keyUse1!: Phaser.Input.Keyboard.Key; keyUse2!: Phaser.Input.Keyboard.Key;
+  keyPick!: Phaser.Input.Keyboard.Key; keyDrop!: Phaser.Input.Keyboard.Key; keyCraft!: Phaser.Input.Keyboard.Key;
+
+  hp = PLAYER_BASE.hp; inv: Inventory = [null, null];
+  itemsGroup!: Phaser.Physics.Arcade.StaticGroup;
+
+  constructor() { super('Play'); }
+
+  preload() {}
+
+  create() {
+    // room bg
+    this.add.rectangle(ROOM_W/2, ROOM_H/2, ROOM_W, ROOM_H, 0x161a22).setStrokeStyle(2, 0x2a3242);
+
+    // furniture (blocking)
+    const blocks = this.physics.add.staticGroup();
+    const addBlock = (x:number,y:number,w:number,h:number)=>{
+      const r = this.add.rectangle(x,y,w,h,0x222831).setStrokeStyle(1,0x3a4152);
+      this.physics.add.existing(r, true);
+      blocks.add(r as any);
+    };
+    addBlock(600, 200, 280, 40); // bed top
+    addBlock(600, 240, 280, 40); // bed bottom
+    addBlock(240, 520, 180, 60); // desk
+    addBlock(980, 520, 120, 60); // dresser
+    addBlock(560, 700, 320, 40); // rug edge (as blocker for proto)
+
+    // player
+    this.player = this.physics.add.sprite(200, 200, '').setCircle(14).setTint(0x88c0ff);
+    this.player.setCollideWorldBounds(true);
+    this.physics.add.collider(this.player, blocks);
+
+    // monster
+    this.monster = new Monster(this, 900, 700);
+    this.physics.add.collider(this.monster, blocks);
+    this.physics.add.overlap(this.monster, this.player, () => {
+      // contact damage once per second (simple throttle)
+      if (!(this.player as any)._lastHit || this.time.now - (this.player as any)._lastHit > 1000) {
+        (this.player as any)._lastHit = this.time.now; this.damagePlayer(1);
+      }
+    });
+
+    // input
+    this.cursors = this.input.keyboard!.createCursorKeys();
+    this.keyUse1 = this.input.keyboard!.addKey('ONE');
+    this.keyUse2 = this.input.keyboard!.addKey('TWO');
+    this.keyPick = this.input.keyboard!.addKey('E');
+    this.keyDrop = this.input.keyboard!.addKey('G');
+    this.keyCraft = this.input.keyboard!.addKey('R');
+
+    // items on ground
+    this.itemsGroup = this.physics.add.staticGroup();
+    const spawn = (x:number,y:number,id: Item['id']) => {
+      const c = this.add.circle(x,y,8,0x7cc7a1); const t = this.add.text(x-12,y-20,id,{fontSize:'10px'});
+      const container = this.add.container(0,0,[c,t]);
+      this.physics.add.existing(container, true);
+      (container as any).itemId = id;
+      this.itemsGroup.add(container as any);
+    };
+    // starter items
+    spawn(260, 560, 'knife');
+    spawn(980, 560, 'bottle');
+    spawn(640, 260, 'soda');
+    spawn(720, 260, 'match');
+    spawn(380, 720, 'bandaid');
+    spawn(680, 720, 'yoyo');
+
+    this.physics.add.overlap(this.player, this.itemsGroup, (_, obj:any) => {
+      (this as any)._overItem = obj;
+    });
+
+    // player hit listener
+    this.player.on('hit', (e: any) => this.damagePlayer(e.dmg||1));
+
+    // HUD once; we’ll redraw per frame (simple for proto)
+  }
+
+  tryPickup() {
+    const obj: any = (this as any)._overItem; if (!obj) return;
+    const id = obj.itemId as Item['id'];
+    // find slot
+    const idx = this.inv[0]? (this.inv[1]? -1 : 1) : 0;
+    if (idx === -1) {
+      // swap with slot 0 by default
+      const dropped = this.inv[0]!; this.inv[0] = { ...cloneItem(id) };
+      (obj as any).itemId = dropped.id; // leave the dropped one on ground
+      (obj.list[1] as Phaser.GameObjects.Text).setText(dropped.id);
+    } else {
+      this.inv[idx] = { ...cloneItem(id) };
+      obj.destroy();
+      (this as any)._overItem = null;
+    }
+  }
+
+  drop(slot: 0|1) {
+    const it = this.inv[slot]; if (!it) return;
+    this.inv[slot] = null;
+    const container = this.add.container(0,0,[this.add.circle(this.player.x+14,this.player.y+14,8,0x7cc7a1), this.add.text(this.player.x,this.player.y,it.id,{fontSize:'10px'})]);
+    this.physics.add.existing(container, true);
+    (container as any).itemId = it.id;
+    this.itemsGroup.add(container as any);
+  }
+
+  use(slot: 0|1) {
+    const it = this.inv[slot]; if (!it) return;
+    const id = it.id; let consumed = true;
+    // minimal effects for stub; numbers per design doc
+    switch(id) {
+      case 'knife': this.tryMelee(2, 48); break;
+      case 'yoyo': this.tryMelee(2, 72); break;
+      case 'bottle': this.throwBottle(2); break;
+      case 'match': this.tryMelee(1, 40, true); break;
+      case 'bandaid': this.hp = Math.min(5, this.hp + 1); break;
+      case 'soda': this.speedBoost(3000); this.afterDelay(3000, () => this.gainBottle(slot)); break;
+      case 'fire_bottle': this.throwBottle(3, true); break;
+      case 'glass_shiv': this.tryMelee(3, 44); break;
+      case 'bladed_yoyo': this.tryMelee(3, 80); break;
+      case 'smoke_patch': /* escape utility placeholder */ break;
+      case 'adrenal_patch': this.hp = Math.min(5, this.hp + 1); this.speedBoost(2000); break;
+      case 'fizz_bomb': this.throwBottle(3, false, true); break;
+      default: consumed = false;
+    }
+    if (consumed) {
+      it.uses -= 1; if (it.uses <= 0) this.inv[slot] = null;
+    }
+  }
+
+  craft() {
+    const a = this.inv[0]?.id; const b = this.inv[1]?.id; if (!a || !b) return;
+    const out = craft(a, b); if (!out) return;
+    // put result into slot 0; clear slot 1 (simple rule for proto)
+    this.inv[0] = { ...cloneItem(out) }; this.inv[1] = null;
+  }
+
+  tryMelee(dmg: number, range: number, fire = false) {
+    const d = Phaser.Math.Distance.Between(this.player.x, this.player.y, this.monster.x, this.monster.y);
+    if (d <= range) this.hitMonster(dmg);
+    if (fire) {/* could apply DoT in later pass */}
+  }
+
+  throwBottle(dmg: number, fire = false, stun = false) {
+    // instant line check for proto
+    const d = Phaser.Math.Distance.Between(this.player.x, this.player.y, this.monster.x, this.monster.y);
+    if (d < 360) {
+      this.hitMonster(dmg);
+      if (stun) this.monster.setVelocity(0,0);
+    }
+  }
+
+  gainBottle(slot: 0|1) {
+    if (!this.inv[slot]) { this.inv[slot] = { id: 'bottle', label: 'Empty Bottle', uses: 1 }; return; }
+    // try other slot
+    const other = slot === 0 ? 1 : 0;
+    if (!this.inv[other]) { this.inv[other] = { id: 'bottle', label: 'Empty Bottle', uses: 1 }; return; }
+    // drop
+    const container = this.add.container(0,0,[this.add.circle(this.player.x+8,this.player.y+8,8,0x7cc7a1), this.add.text(this.player.x-12,this.player.y-20,'bottle',{fontSize:'10px'})]);
+    this.physics.add.existing(container, true);
+    (container as any).itemId = 'bottle';
+    this.itemsGroup.add(container as any);
+  }
+
+  damagePlayer(n: number) {
+    this.hp -= n; this.cameras.main.shake(80, 0.004);
+    if (this.hp <= 0) this.scene.restart();
+  }
+
+  hitMonster(n: number) {
+    this.monster.hp -= n;
+    this.monster.setTint(0xffdddd); this.time.delayedCall(80, () => this.monster.clearTint());
+    if (this.monster.hp <= 0) this.scene.restart();
+  }
+
+  speedBoost(ms: number) {
+    (this.player.body as Phaser.Physics.Arcade.Body).maxSpeed = 360;
+    this.time.delayedCall(ms, () => (this.player.body as Phaser.Physics.Arcade.Body).maxSpeed = 260);
+  }
+
+  afterDelay(ms:number, fn:()=>void) { this.time.delayedCall(ms, fn); }
+
+  update(time: number, delta: number) {
+    // movement
+    const body = this.player.body as Phaser.Physics.Arcade.Body;
+    const speed = 260; body.setVelocity(0,0);
+    if (this.cursors.left?.isDown) body.setVelocityX(-speed);
+    if (this.cursors.right?.isDown) body.setVelocityX(speed);
+    if (this.cursors.up?.isDown) body.setVelocityY(-speed);
+    if (this.cursors.down?.isDown) body.setVelocityY(speed);
+
+    // interaction
+    if (Phaser.Input.Keyboard.JustDown(this.keyPick)) this.tryPickup();
+    if (Phaser.Input.Keyboard.JustDown(this.keyDrop)) this.drop(0);
+    if (Phaser.Input.Keyboard.JustDown(this.keyUse1)) this.use(0);
+    if (Phaser.Input.Keyboard.JustDown(this.keyUse2)) this.use(1);
+    if (Phaser.Input.Keyboard.JustDown(this.keyCraft)) this.craft();
+
+    // monster update
+    this.monster.update(delta/1000, this.player);
+
+    // HUD
+    this.children.removeAll(); // simple redraw for proto (cheap at small scale)
+    this.add.rectangle(ROOM_W/2, ROOM_H/2, ROOM_W, ROOM_H, 0x161a22).setStrokeStyle(2, 0x2a3242);
+    drawHUD(this, this.hp, 5, this.inv);
+  }
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,0 +1,19 @@
+import type Phaser from 'phaser';
+import type { Inventory, Item } from '@game/types';
+
+export function drawHUD(scene: Phaser.Scene, hp: number, maxHp: number, inv: Inventory) {
+  const g = scene.add.graphics();
+  g.fillStyle(0x111111, 0.6).fillRoundedRect(12, 12, 220, 64, 8);
+  // hearts
+  for (let i=0;i<maxHp;i++) {
+    const c = i < hp ? 0xff4d4d : 0x444444;
+    g.fillStyle(c, 1).fillCircle(28 + i*20, 32, 7);
+  }
+  // slots
+  const slotBox = (x:number, i:number, it: Item|null) => {
+    g.lineStyle(1, 0x999999, 0.8).strokeRoundedRect(x, 52, 90, 20, 4);
+    scene.add.text(x+6, 52, `${i+1}: ${it? it.label: '—'}${it? ` (${it.uses})`: ''}`, { fontFamily: 'monospace', fontSize: '12px' });
+  };
+  slotBox(16, 0, inv[0]);
+  slotBox(112, 1, inv[1]);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@game/*": ["src/game/*"],
+      "@scenes/*": ["src/scenes/*"],
+      "@ui/*": ["src/ui/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+
+// If your repo is named something else, set base to "/<repo-name>/".
+export default defineConfig({
+  base: '/bedroom-monster/',
+});


### PR DESCRIPTION
## Summary
- add GitHub Pages deployment workflow and issue templates for structured planning
- scaffold Phaser + TypeScript bedroom prototype with core scene, items, monster, and HUD
- configure Vite, TypeScript paths, and project metadata for building and hosting

## Testing
- npm install *(fails: 403 Forbidden downloading phaser)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a0c690808332901acd5ee2e7d069