### PR TITLE
Add Node 18 runtime requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Top-down survival prototype built with Phaser + TypeScript. **GitHub-only workfl
 Enable GitHub Pages → Source: **GitHub Actions**. The Actions workflow in `.github/workflows/deploy.yml` deploys `dist/`.
 
 ## Scripts
+- Requires **Node.js ≥18**.
 - `npm run dev` – local dev (optional if using Codespaces)
 - `npm run build` – build to `dist/`
 - `npm run preview` – serve the build locally

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "bedroom-monster",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- declare Node.js >=18 support requirement via package.json engines field
- mention the Node >=18 prerequisite in the README setup instructions

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8a6a9e2248332bae700b647eed48d