### PR TITLE
Refactor PlayScene HUD to use persistent container

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -4,7 +4,7 @@ import type { Inventory, Item } from '@game/types';
 import { cloneItem } from '@game/items';
 import { craft } from '@game/recipes';
 import { Monster } from '@game/monster';
-import { drawHUD } from '@ui/hud';
+import { createHUD, drawHUD, type HudElements } from '@ui/hud';
 
 export class PlayScene extends Phaser.Scene {
   player!: Phaser.Physics.Arcade.Sprite;
@@ -15,6 +15,7 @@ export class PlayScene extends Phaser.Scene {
 
   hp = PLAYER_BASE.hp; inv: Inventory = [null, null];
   itemsGroup!: Phaser.Physics.Arcade.StaticGroup;
+  hud!: HudElements;
 
   constructor() { super('Play'); }
 
@@ -84,7 +85,8 @@ export class PlayScene extends Phaser.Scene {
     // player hit listener
     this.player.on('hit', (e: any) => this.damagePlayer(e.dmg||1));
 
-    // HUD once; we’ll redraw per frame (simple for proto)
+    // HUD
+    this.hud = createHUD(this, 5);
   }
 
   tryPickup() {
@@ -209,8 +211,6 @@ export class PlayScene extends Phaser.Scene {
     this.monster.update(delta/1000, this.player);
 
     // HUD
-    this.children.removeAll(); // simple redraw for proto (cheap at small scale)
-    this.add.rectangle(ROOM_W/2, ROOM_H/2, ROOM_W, ROOM_H, 0x161a22).setStrokeStyle(2, 0x2a3242);
-    drawHUD(this, this.hp, 5, this.inv);
+    drawHUD(this.hud, this.hp, 5, this.inv);
   }
 }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,19 +1,63 @@
 import type Phaser from 'phaser';
 import type { Inventory, Item } from '@game/types';
 
-export function drawHUD(scene: Phaser.Scene, hp: number, maxHp: number, inv: Inventory) {
-  const g = scene.add.graphics();
-  g.fillStyle(0x111111, 0.6).fillRoundedRect(12, 12, 220, 64, 8);
-  // hearts
-  for (let i=0;i<maxHp;i++) {
-    const c = i < hp ? 0xff4d4d : 0x444444;
-    g.fillStyle(c, 1).fillCircle(28 + i*20, 32, 7);
-  }
-  // slots
-  const slotBox = (x:number, i:number, it: Item|null) => {
-    g.lineStyle(1, 0x999999, 0.8).strokeRoundedRect(x, 52, 90, 20, 4);
-    scene.add.text(x+6, 52, `${i+1}: ${it? it.label: '—'}${it? ` (${it.uses})`: ''}`, { fontFamily: 'monospace', fontSize: '12px' });
+export type HudElements = {
+  container: Phaser.GameObjects.Container;
+  hearts: Phaser.GameObjects.Graphics;
+  slotTexts: [Phaser.GameObjects.Text, Phaser.GameObjects.Text];
+};
+
+export function createHUD(scene: Phaser.Scene, maxHp: number): HudElements {
+  const container = scene.add.container(0, 0);
+  container.setDepth(1000);
+  container.setScrollFactor(0);
+
+  const frame = scene.add.graphics();
+  frame.fillStyle(0x111111, 0.6).fillRoundedRect(12, 12, 220, 64, 8);
+  frame.lineStyle(1, 0x999999, 0.8).strokeRoundedRect(16, 52, 90, 20, 4);
+  frame.strokeRoundedRect(112, 52, 90, 20, 4);
+  frame.setScrollFactor(0);
+  container.add(frame);
+
+  const hearts = scene.add.graphics();
+  hearts.setScrollFactor(0);
+  container.add(hearts);
+
+  const makeSlotText = (x: number, idx: number) => {
+    const text = scene.add.text(x + 6, 52, `${idx + 1}: —`, {
+      fontFamily: 'monospace',
+      fontSize: '12px',
+    });
+    text.setScrollFactor(0);
+    container.add(text);
+    return text;
   };
-  slotBox(16, 0, inv[0]);
-  slotBox(112, 1, inv[1]);
+
+  const slotTexts: [Phaser.GameObjects.Text, Phaser.GameObjects.Text] = [
+    makeSlotText(16, 0),
+    makeSlotText(112, 1),
+  ];
+
+  // initialize once so the HUD starts with correct values
+  const initialInv: Inventory = [null, null];
+  drawHUD({ container, hearts, slotTexts }, maxHp, maxHp, initialInv);
+
+  return { container, hearts, slotTexts };
+}
+
+function slotLabel(i: number, it: Item | null) {
+  return `${i + 1}: ${it ? it.label : '—'}${it ? ` (${it.uses})` : ''}`;
+}
+
+export function drawHUD(hud: HudElements, hp: number, maxHp: number, inv: Inventory) {
+  const { hearts, slotTexts } = hud;
+
+  hearts.clear();
+  for (let i = 0; i < maxHp; i += 1) {
+    const color = i < hp ? 0xff4d4d : 0x444444;
+    hearts.fillStyle(color, 1).fillCircle(28 + i * 20, 32, 7);
+  }
+
+  slotTexts[0].setText(slotLabel(0, inv[0]));
+  slotTexts[1].setText(slotLabel(1, inv[1]));
 }


### PR DESCRIPTION
## Summary
- add a dedicated HUD container with persistent graphics and text that can be updated in-place
- update PlayScene to stop clearing scene children each frame so world actors remain active
- reuse the HUD container during updates to refresh health and inventory information only

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8a7f860c8833292555c8a08dce62f