### PR TITLE
Add telegraphed monster attack animations

### DIFF
--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -8,12 +8,29 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
   cd = { sweep: 0, smash: 0, rush: 0, roar: 0 };
   speed = 140;
   target?: Phaser.Types.Physics.Arcade.GameObjectWithBody;
+  private baseTint = 0xff8844;
+  private baseScale = { x: 1, y: 1 };
+  private baseAngle = 0;
+  private actionLock = false;
+  private currentTimeline?: Phaser.Tweens.Timeline;
+  private idleTween?: Phaser.Tweens.Tween;
 
   constructor(scene: Phaser.Scene, x: number, y: number) {
     super(scene, x, y, '');
     scene.add.existing(this);
     scene.physics.add.existing(this);
-    this.setCircle(18).setOffset(0,0).setTint(0xff8844);
+    this.setCircle(18).setOffset(0,0).setTint(this.baseTint);
+
+    // Gentle idle breathing so the monster feels alive between actions.
+    this.idleTween = scene.tweens.add({
+      targets: this,
+      scaleX: { from: 1, to: 1.04 },
+      scaleY: { from: 1, to: 0.96 },
+      duration: 900,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut',
+    });
   }
 
   update(dt: number, player: Phaser.Physics.Arcade.Sprite) {
@@ -22,6 +39,20 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
 
     // cooldowns
     for (const k in this.cd) (this.cd as any)[k] = Math.max(0, (this.cd as any)[k] - dt);
+
+    // maintain a gentle sway while walking unless a telegraph is running.
+    if (!this.actionLock && this.body) {
+      const speed = (this.body.velocity.length() || 0);
+      if (speed > 40) {
+        this.idleTween?.pause();
+        this.setScale(1.05, 0.95);
+      } else if (!this.currentTimeline) {
+        this.resetPose();
+        this.idleTween?.resume();
+      }
+    }
+
+    if (this.actionLock) return;
 
     // simple steering
     if (this.state === 'wander') {
@@ -38,26 +69,149 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
     }
   }
 
+  private startAction(
+    action: 'sweep'|'smash'|'rush'|'roar',
+    tweens: Phaser.Types.Tweens.TweenBuilderConfig | Phaser.Types.Tweens.TweenBuilderConfig[]
+  ) {
+    if (this.actionLock) return;
+
+    this.actionLock = true;
+    this.setVelocity(0, 0);
+    this.currentTimeline?.stop();
+    this.idleTween?.pause();
+
+    const timelineTweens = Array.isArray(tweens) ? tweens : [tweens];
+
+    this.currentTimeline = this.scene.tweens.timeline({
+      targets: this,
+      tweens: timelineTweens,
+      onComplete: () => {
+        this.resetPose();
+        this.actionLock = false;
+        this.currentTimeline = undefined;
+        this.idleTween?.resume();
+      },
+    });
+  }
+
+  private resetPose() {
+    this.setScale(this.baseScale.x, this.baseScale.y);
+    this.setAngle(this.baseAngle);
+    this.setTint(this.baseTint);
+  }
+
   sweep(player: Phaser.Physics.Arcade.Sprite) {
-    // close cone check → knockback  
-    if (Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y) < 80) {
-      player.emit('hit', { dmg: 1, type: 'sweep' });
-    }
+    this.startAction('sweep', [
+      {
+        duration: 200,
+        scaleX: 0.9,
+        scaleY: 1.1,
+        angle: -15,
+        ease: 'Sine.easeOut',
+        onStart: () => this.setTint(0xffbb55),
+      },
+      {
+        duration: 220,
+        scaleX: 1.35,
+        scaleY: 0.75,
+        angle: 20,
+        ease: 'Back.easeOut',
+        onStart: () => {
+          if (Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y) < 80) {
+            player.emit('hit', { dmg: 1, type: 'sweep' });
+          }
+        },
+      },
+      {
+        duration: 180,
+        scaleX: this.baseScale.x,
+        scaleY: this.baseScale.y,
+        angle: this.baseAngle,
+        ease: 'Sine.easeInOut',
+      },
+    ]);
   }
   smash(player: Phaser.Physics.Arcade.Sprite) {
-    if (Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y) < 120) {
-      player.emit('hit', { dmg: 1, type: 'smash' });
-    }
+    this.startAction('smash', [
+      {
+        duration: 260,
+        scaleX: 0.8,
+        scaleY: 1.2,
+        ease: 'Quad.easeOut',
+        onStart: () => this.setTint(0xffcc77),
+      },
+      {
+        duration: 160,
+        scaleX: 1.4,
+        scaleY: 0.7,
+        ease: 'Bounce.easeOut',
+        onStart: () => {
+          if (Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y) < 120) {
+            player.emit('hit', { dmg: 1, type: 'smash' });
+          }
+        },
+      },
+      {
+        duration: 200,
+        scaleX: this.baseScale.x,
+        scaleY: this.baseScale.y,
+        angle: this.baseAngle,
+        ease: 'Sine.easeInOut',
+      },
+    ]);
   }
   rush(player: Phaser.Physics.Arcade.Sprite) {
-    // brief burst
-    const v = this.scene.physics.velocityFromRotation(
-      Phaser.Math.Angle.Between(this.x, this.y, player.x, player.y), 320);
-    this.setVelocity(v.x, v.y);
+    this.startAction('rush', [
+      {
+        duration: 220,
+        scaleX: 0.85,
+        scaleY: 1.2,
+        ease: 'Sine.easeIn',
+        onStart: () => this.setTint(0xeeaa55),
+      },
+      {
+        duration: 100,
+        scaleX: 1.5,
+        scaleY: 0.7,
+        ease: 'Expo.easeOut',
+        onStart: () => {
+          const v = this.scene.physics.velocityFromRotation(
+            Phaser.Math.Angle.Between(this.x, this.y, player.x, player.y), 340);
+          this.setVelocity(v.x, v.y);
+        },
+      },
+      {
+        duration: 240,
+        scaleX: this.baseScale.x,
+        scaleY: this.baseScale.y,
+        ease: 'Quad.easeOut',
+        onStart: () => this.scene.time.delayedCall(60, () => this.setVelocity(0, 0)),
+      },
+    ]);
   }
   roar(player: Phaser.Physics.Arcade.Sprite) {
-    // slow effect placeholder
-    this.setTintFill(0xffaa66);
-    this.scene.time.delayedCall(200, () => this.clearTint());
+    this.startAction('roar', [
+      {
+        duration: 180,
+        scaleX: 1.05,
+        scaleY: 1.05,
+        ease: 'Sine.easeInOut',
+        onStart: () => this.setTintFill(0xffdd88),
+      },
+      {
+        duration: 180,
+        scaleX: 1.15,
+        scaleY: 1.15,
+        ease: 'Sine.easeInOut',
+        onStart: () => player.emit('hit', { dmg: 0, type: 'roar' }),
+      },
+      {
+        duration: 180,
+        scaleX: this.baseScale.x,
+        scaleY: this.baseScale.y,
+        ease: 'Sine.easeOut',
+        onStart: () => this.setTint(this.baseTint),
+      },
+    ]);
   }
 }


### PR DESCRIPTION
## Summary
- introduce reusable helper to queue monster telegraph timelines with reset handling
- add bespoke sweep, smash, rush, and roar animations that signal the hit before applying effects
- pause idle sway while actions play and resume once the monster returns to neutral

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8aba693f483328c8bad5a74cd31e6