### PR TITLE
Document Vite requirement for running the game

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Enable GitHub Pages → Source: **GitHub Actions**. The Actions workflow in `.gi
 - `npm run build` – build to `dist/`
 - `npm run preview` – serve the build locally
 
+> ℹ️ **Do not open `index.html` directly in the browser.** Browsers cannot execute the TypeScript entry (`src/main.ts`) referenced by the page, so nothing will render.
+> Always run through Vite via `npm run dev` (or `npm run build`/`npm run preview`) so the TypeScript is compiled before loading.
+
 ## Controls
 - Move: Arrow keys
 - Interact: `E` (pickup/swap), `G` (drop slot 1)


### PR DESCRIPTION
## Summary
- add an explicit note in the README explaining that the game must be served through Vite
- clarify that opening index.html directly will not render because browsers cannot load the TypeScript entry point

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d93117ce048332b98ccda90b6b390d