### PR TITLE
Align telegraphs with attack shapes

### DIFF
--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -14,6 +14,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
   private actionLock = false;
   private currentChain?: Phaser.Tweens.TweenChain;
   private idleTween?: Phaser.Tweens.Tween;
+  private telegraphDepth = 90;
 
   constructor(scene: Phaser.Scene, x: number, y: number) {
     super(scene, x, y, 'monster-circle');
@@ -103,6 +104,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
   }
 
   sweep(player: Phaser.Physics.Arcade.Sprite) {
+    this.showSweepTelegraph(player, 120, 0xffbb55, '🌀', 360);
     this.startAction('sweep', [
       {
         duration: 200,
@@ -121,6 +123,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
         onStart: () => {
           if (Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y) < 80) {
             player.emit('hit', { dmg: 1, type: 'sweep' });
+            this.spawnImpactEmoji(player.x, player.y - 20, '💫', 0xffd18a);
           }
         },
       },
@@ -134,6 +137,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
     ]);
   }
   smash(player: Phaser.Physics.Arcade.Sprite) {
+    this.showSmashTelegraph(player, 130, 0xffcc77, '🔨', 380);
     this.startAction('smash', [
       {
         duration: 260,
@@ -150,6 +154,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
         onStart: () => {
           if (Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y) < 120) {
             player.emit('hit', { dmg: 1, type: 'smash' });
+            this.spawnImpactEmoji(player.x, player.y - 26, '💥', 0xfff2c6);
           }
         },
       },
@@ -163,6 +168,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
     ]);
   }
   rush(player: Phaser.Physics.Arcade.Sprite) {
+    this.showRushTelegraph(player, 280, 0xeeaa55, '⚡', 360);
     this.startAction('rush', [
       {
         duration: 220,
@@ -188,10 +194,12 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
         scaleY: this.baseScale.y,
         ease: 'Quad.easeOut',
         onStart: () => this.scene.time.delayedCall(60, () => this.setVelocity(0, 0)),
+        onComplete: () => this.spawnImpactEmoji(this.x, this.y - 28, '💢', 0xffe0b3),
       },
     ]);
   }
   roar(player: Phaser.Physics.Arcade.Sprite) {
+    this.showRoarTelegraph(190, 0xffdd88, '🗯️', 420);
     this.startAction('roar', [
       {
         duration: 180,
@@ -205,7 +213,10 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
         scaleX: 1.15,
         scaleY: 1.15,
         ease: 'Sine.easeInOut',
-        onStart: () => player.emit('hit', { dmg: 0, type: 'roar' }),
+        onStart: () => {
+          player.emit('hit', { dmg: 0, type: 'roar' });
+          this.spawnImpactEmoji(player.x, player.y - 34, '😱', 0xfff2c6);
+        },
       },
       {
         duration: 180,
@@ -215,5 +226,228 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
         onStart: () => this.setTint(this.baseTint),
       },
     ]);
+  }
+
+  private showSweepTelegraph(
+    player: Phaser.Physics.Arcade.Sprite,
+    range: number,
+    color: number,
+    emoji: string,
+    duration: number,
+  ) {
+    const spread = Phaser.Math.DegToRad(150);
+    const gfx = this.scene.add.graphics({ x: this.x, y: this.y })
+      .setDepth(this.telegraphDepth)
+      .setScale(0.4)
+      .setAlpha(0.85);
+    gfx.fillStyle(color, 0.2);
+    gfx.beginPath();
+    gfx.moveTo(0, 0);
+    gfx.arc(0, 0, range, -spread / 2, spread / 2, false);
+    gfx.closePath();
+    gfx.fillPath();
+    gfx.lineStyle(3, color, 0.95);
+    gfx.beginPath();
+    gfx.arc(0, 0, range, -spread / 2, spread / 2, false);
+    gfx.strokePath();
+
+    const icon = this.scene.add.text(this.x, this.y, emoji, { fontSize: '30px' })
+      .setOrigin(0.5)
+      .setDepth(this.telegraphDepth + 1)
+      .setAlpha(0.95)
+      .setScale(0.85);
+
+    const updatePositions = () => {
+      const angle = Phaser.Math.Angle.Between(this.x, this.y, player.x, player.y);
+      gfx.setPosition(this.x, this.y);
+      gfx.setRotation(angle);
+      const tipX = this.x + Math.cos(angle) * range * 0.9;
+      const tipY = this.y + Math.sin(angle) * range * 0.9;
+      if (icon.active) icon.setPosition(tipX, tipY - 20);
+    };
+
+    updatePositions();
+
+    this.scene.tweens.add({
+      targets: gfx,
+      scale: { from: 0.4, to: 1 },
+      alpha: { from: 0.85, to: 0 },
+      ease: 'Cubic.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => gfx.destroy(),
+    });
+
+    this.scene.tweens.add({
+      targets: icon,
+      alpha: { from: 0.95, to: 0 },
+      scale: { from: 0.85, to: 1.25 },
+      ease: 'Sine.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => icon.destroy(),
+    });
+  }
+
+  private showSmashTelegraph(
+    player: Phaser.Physics.Arcade.Sprite,
+    range: number,
+    color: number,
+    emoji: string,
+    duration: number,
+  ) {
+    const circle = this.scene.add.circle(this.x, this.y, range * 0.55, color, 0.2)
+      .setDepth(this.telegraphDepth)
+      .setStrokeStyle(3, color, 0.95)
+      .setScale(0.3)
+      .setAlpha(0.85);
+    const icon = this.scene.add.text(this.x, this.y, emoji, { fontSize: '32px' })
+      .setOrigin(0.5)
+      .setDepth(this.telegraphDepth + 1)
+      .setAlpha(0.95);
+
+    const updatePositions = () => {
+      const angle = Phaser.Math.Angle.Between(this.x, this.y, player.x, player.y);
+      const dist = Math.min(range - 20, Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y));
+      const cx = this.x + Math.cos(angle) * dist * 0.8;
+      const cy = this.y + Math.sin(angle) * dist * 0.8;
+      circle.setPosition(cx, cy);
+      if (icon.active) icon.setPosition(cx, cy - 28);
+    };
+
+    updatePositions();
+
+    this.scene.tweens.add({
+      targets: circle,
+      scale: { from: 0.3, to: 1 },
+      alpha: { from: 0.85, to: 0 },
+      ease: 'Back.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => circle.destroy(),
+    });
+
+    this.scene.tweens.add({
+      targets: icon,
+      alpha: { from: 0.95, to: 0 },
+      y: { from: icon.y, to: icon.y - 12 },
+      scale: { from: 0.85, to: 1.2 },
+      ease: 'Sine.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => icon.destroy(),
+    });
+  }
+
+  private showRushTelegraph(
+    player: Phaser.Physics.Arcade.Sprite,
+    maxDistance: number,
+    color: number,
+    emoji: string,
+    duration: number,
+  ) {
+    const thickness = 46;
+    const rect = this.scene.add.rectangle(this.x, this.y, maxDistance, thickness, color, 0.18)
+      .setDepth(this.telegraphDepth)
+      .setOrigin(0, 0.5)
+      .setScale(0.1, 1)
+      .setAlpha(0.85);
+    const icon = this.scene.add.text(this.x, this.y, emoji, { fontSize: '32px' })
+      .setOrigin(0.5)
+      .setDepth(this.telegraphDepth + 1)
+      .setAlpha(0.95)
+      .setScale(0.9);
+
+    const updatePositions = () => {
+      const angle = Phaser.Math.Angle.Between(this.x, this.y, player.x, player.y);
+      const travel = Math.min(maxDistance, Phaser.Math.Distance.Between(this.x, this.y, player.x, player.y) + 120);
+      rect.setPosition(this.x, this.y);
+      rect.setRotation(angle);
+      if (icon.active) icon.setPosition(this.x + Math.cos(angle) * travel, this.y + Math.sin(angle) * travel);
+    };
+
+    updatePositions();
+
+    this.scene.tweens.add({
+      targets: rect,
+      scaleX: { from: 0.1, to: 1 },
+      alpha: { from: 0.85, to: 0 },
+      ease: 'Expo.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => rect.destroy(),
+    });
+
+    this.scene.tweens.add({
+      targets: icon,
+      alpha: { from: 0.95, to: 0 },
+      scale: { from: 0.9, to: 1.3 },
+      ease: 'Sine.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => icon.destroy(),
+    });
+  }
+
+  private showRoarTelegraph(range: number, color: number, emoji: string, duration: number) {
+    const outer = this.scene.add.circle(this.x, this.y, range, color, 0.14)
+      .setDepth(this.telegraphDepth)
+      .setStrokeStyle(4, color, 0.9)
+      .setAlpha(0.8)
+      .setScale(0.4);
+    const inner = this.scene.add.circle(this.x, this.y, range * 0.55, color, 0)
+      .setDepth(this.telegraphDepth)
+      .setStrokeStyle(2, color, 0.6)
+      .setAlpha(0.7)
+      .setScale(0.4);
+    const icon = this.scene.add.text(this.x, this.y - range - 12, emoji, { fontSize: '32px' })
+      .setOrigin(0.5)
+      .setDepth(this.telegraphDepth + 1)
+      .setAlpha(0.95);
+
+    const updatePositions = () => {
+      outer.setPosition(this.x, this.y);
+      inner.setPosition(this.x, this.y);
+      if (icon.active) icon.setPosition(this.x, this.y - range - 12);
+    };
+
+    updatePositions();
+
+    this.scene.tweens.add({
+      targets: [outer, inner],
+      scale: { from: 0.4, to: 1 },
+      alpha: { from: 0.8, to: 0 },
+      ease: 'Cubic.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => { outer.destroy(); inner.destroy(); },
+    });
+
+    this.scene.tweens.add({
+      targets: icon,
+      alpha: { from: 0.95, to: 0 },
+      y: { from: icon.y, to: icon.y - 12 },
+      scale: { from: 0.9, to: 1.25 },
+      ease: 'Sine.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => icon.destroy(),
+    });
+  }
+
+  private spawnImpactEmoji(x: number, y: number, emoji: string, tint: number) {
+    const icon = this.scene.add.text(x, y, emoji, { fontSize: '26px' })
+      .setOrigin(0.5)
+      .setDepth(this.telegraphDepth + 2);
+    icon.setTint(tint);
+
+    this.scene.tweens.add({
+      targets: icon,
+      alpha: { from: 1, to: 0 },
+      y: y - 18,
+      duration: 420,
+      ease: 'Sine.easeOut',
+      onComplete: () => icon.destroy(),
+    });
   }
 }

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -21,6 +21,7 @@ export class PlayScene extends Phaser.Scene {
   hp = PLAYER_BASE.hp; inv: Inventory = [null, null];
   itemsGroup!: Phaser.Physics.Arcade.StaticGroup;
   hud!: HudElements;
+  private fxDepth = 200;
 
   constructor() { super('Play'); }
 
@@ -61,10 +62,12 @@ export class PlayScene extends Phaser.Scene {
     this.player.setDisplaySize(32, 32);
     this.player.setCircle(14, 2, 2);
     this.player.setCollideWorldBounds(true);
+    this.player.setDepth(10);
     this.physics.add.collider(this.player, blocks);
 
     // monster
     this.monster = new Monster(this, 900, 700);
+    this.monster.setDepth(10);
     this.physics.add.collider(this.monster, blocks);
     this.physics.add.overlap(this.monster, this.player, () => {
       // contact damage once per second (simple throttle)
@@ -171,16 +174,20 @@ export class PlayScene extends Phaser.Scene {
   }
 
   tryMelee(dmg: number, range: number, fire = false) {
+    this.showMeleeTelegraph(range, fire ? 0xff8844 : 0x6cc4ff, fire ? '🔥' : '🗡️');
     const d = Phaser.Math.Distance.Between(this.player.x, this.player.y, this.monster.x, this.monster.y);
-    if (d <= range) this.hitMonster(dmg);
+    if (d <= range) {
+      this.hitMonster(dmg, fire ? '🔥' : '💥');
+    }
     if (fire) {/* could apply DoT in later pass */}
   }
 
   throwBottle(dmg: number, fire = false, stun = false) {
     // instant line check for proto
     const d = Phaser.Math.Distance.Between(this.player.x, this.player.y, this.monster.x, this.monster.y);
+    this.showThrowTelegraph(360, fire ? 0xff9966 : 0x88d5ff, fire ? '🍷' : (stun ? '💨' : '🍾'), 420);
     if (d < 360) {
-      this.hitMonster(dmg);
+      this.hitMonster(dmg, fire ? '🔥' : stun ? '💫' : '💥');
       if (stun) this.monster.setVelocity(0,0);
     }
   }
@@ -210,18 +217,141 @@ export class PlayScene extends Phaser.Scene {
     if (this.hp <= 0) this.scene.restart();
   }
 
-  hitMonster(n: number) {
+  hitMonster(n: number, emoji: string = '💥') {
     this.monster.hp -= n;
     this.monster.setTint(0xffdddd); this.time.delayedCall(80, () => this.monster.clearTint());
+    this.spawnFloatingEmoji(this.monster.x, this.monster.y - 30, emoji, 26, 0xfff4d3);
     if (this.monster.hp <= 0) this.scene.restart();
   }
 
   speedBoost(ms: number) {
     (this.player.body as Phaser.Physics.Arcade.Body).maxSpeed = 360;
     this.time.delayedCall(ms, () => (this.player.body as Phaser.Physics.Arcade.Body).maxSpeed = 260);
+    this.spawnFloatingEmoji(this.player.x, this.player.y - 40, '⚡', 24, 0xe8ff9e, ms);
   }
 
   afterDelay(ms:number, fn:()=>void) { this.time.delayedCall(ms, fn); }
+
+  private getPlayerFacingAngle() {
+    if (!this.monster?.active) return -Math.PI / 2;
+    return Phaser.Math.Angle.Between(this.player.x, this.player.y, this.monster.x, this.monster.y);
+  }
+
+  private showMeleeTelegraph(range: number, color: number, emoji: string, duration = 300) {
+    const spread = Phaser.Math.DegToRad(120);
+    const gfx = this.add.graphics({ x: this.player.x, y: this.player.y });
+    gfx.setDepth(this.fxDepth).setAlpha(0.85).setScale(0.45);
+    gfx.fillStyle(color, 0.22);
+    gfx.beginPath();
+    gfx.moveTo(0, 0);
+    gfx.arc(0, 0, range, -spread / 2, spread / 2, false);
+    gfx.closePath();
+    gfx.fillPath();
+    gfx.lineStyle(3, color, 0.95);
+    gfx.beginPath();
+    gfx.arc(0, 0, range, -spread / 2, spread / 2, false);
+    gfx.strokePath();
+
+    const icon = this.add.text(this.player.x, this.player.y, emoji, { fontSize: '28px' })
+      .setOrigin(0.5)
+      .setDepth(this.fxDepth + 1)
+      .setAlpha(0.95)
+      .setScale(0.9);
+
+    const updatePositions = () => {
+      const angle = this.getPlayerFacingAngle();
+      gfx.setPosition(this.player.x, this.player.y);
+      gfx.setRotation(angle);
+      const tipX = this.player.x + Math.cos(angle) * range * 0.92;
+      const tipY = this.player.y + Math.sin(angle) * range * 0.92;
+      if (icon.active) icon.setPosition(tipX, tipY - 18);
+    };
+
+    updatePositions();
+
+    this.tweens.add({
+      targets: gfx,
+      scale: { from: 0.45, to: 1 },
+      alpha: { from: 0.85, to: 0 },
+      ease: 'Cubic.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => gfx.destroy(),
+    });
+
+    this.tweens.add({
+      targets: icon,
+      alpha: { from: 0.95, to: 0 },
+      scale: { from: 0.9, to: 1.3 },
+      ease: 'Sine.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => icon.destroy(),
+    });
+  }
+
+  private showThrowTelegraph(range: number, color: number, emoji: string, duration = 420) {
+    const thickness = 24;
+    const rect = this.add.rectangle(this.player.x, this.player.y, range, thickness, color, 0.2)
+      .setDepth(this.fxDepth)
+      .setOrigin(0, 0.5)
+      .setAlpha(0.9)
+      .setScale(0.1, 1);
+
+    const icon = this.add.text(this.player.x, this.player.y, emoji, { fontSize: '26px' })
+      .setOrigin(0.5)
+      .setDepth(this.fxDepth + 1)
+      .setAlpha(0.95)
+      .setScale(0.85);
+
+    const updatePositions = () => {
+      const angle = this.getPlayerFacingAngle();
+      rect.setPosition(this.player.x, this.player.y);
+      rect.setRotation(angle);
+      const tipX = this.player.x + Math.cos(angle) * range;
+      const tipY = this.player.y + Math.sin(angle) * range;
+      if (icon.active) icon.setPosition(tipX, tipY);
+    };
+
+    updatePositions();
+
+    this.tweens.add({
+      targets: rect,
+      scaleX: { from: 0.1, to: 1 },
+      alpha: { from: 0.9, to: 0 },
+      ease: 'Cubic.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => rect.destroy(),
+    });
+
+    this.tweens.add({
+      targets: icon,
+      alpha: { from: 0.95, to: 0 },
+      scale: { from: 0.85, to: 1.2 },
+      ease: 'Sine.easeOut',
+      duration,
+      onUpdate: updatePositions,
+      onComplete: () => icon.destroy(),
+    });
+  }
+
+  private spawnFloatingEmoji(x: number, y: number, emoji: string, fontSize = 24, tint = 0xffffff, duration = 480) {
+    const label = this.add.text(x, y, emoji, {
+      fontSize: `${fontSize}px`,
+    }).setOrigin(0.5).setDepth(this.fxDepth + 2);
+
+    label.setTint(tint);
+
+    this.tweens.add({
+      targets: label,
+      alpha: { from: 1, to: 0 },
+      y: y - 20,
+      duration,
+      ease: 'Sine.easeOut',
+      onComplete: () => label.destroy(),
+    });
+  }
 
   update(time: number, delta: number) {
     // movement


### PR DESCRIPTION
## Summary
- render player melee telegraphs as directed cones and bottles as aimed lanes that follow the target
- tailor monster telegraphs to each move with sweep cones, smash impact circles, rush lanes, and roar shockwaves

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d98b9e9b008332a0aea73d2eb28499