### PR TITLE
Use sprite sheets and add restock timer

### DIFF
--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -1,5 +1,5 @@
-export const ROOM_W = 1200;
-export const ROOM_H = 900;
+export const ROOM_W = 1280;
+export const ROOM_H = 720;
 
 export const PLAYER_BASE = { hp: 5, maxHp: 5, speed: 200 } as const;
 export const MONSTER_BASE = { hp: 12, speed: 160 } as const; // slower than player; tuned in-scene


### PR DESCRIPTION
## Summary
- replace the placeholder player and monster circles with animations driven by the provided sprite sheets and adjust their physics bodies
- add a furniture restock timer that repopulates items every 15 seconds whenever fewer than four ground items remain
- resize the arena to 1280x720 so the play space fits within a typical browser viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6d3e7a208332a3214b5789406d89