### PR TITLE
Fix player spawn to avoid overlapping furniture

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -125,7 +125,7 @@ export class PlayScene extends Phaser.Scene {
 
 
     // player
-    this.player = this.physics.add.sprite(200, 200, 'player', 16);
+    this.player = this.physics.add.sprite(640, 480, 'player', 16);
     this.player.setScale(0.5);
     const playerBody = this.player.body as Phaser.Physics.Arcade.Body;
     playerBody.setSize(28, 32);


### PR DESCRIPTION
## Summary
- update the player's starting position to an open space so they no longer spawn inside furniture

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da9369a75083328979ff98e75d2439