### PR TITLE
Add inventory use indicators and load item textures

### DIFF
--- a/src/game/items.ts
+++ b/src/game/items.ts
@@ -41,4 +41,10 @@ export const BASE_ITEMS: Record<ItemId, Item> = {
   fizz_bomb: { id: 'fizz_bomb', label: 'Fizz Pop Bomb', uses: 1, icon: ITEM_TEXTURE_KEYS.fizz_bomb },
 };
 
-export function cloneItem(id: ItemId): Item { const b = BASE_ITEMS[id]; return { ...b, data: { ...(b.data||{}) } }; }
+export function cloneItem(id: ItemId): Item {
+  const b = BASE_ITEMS[id];
+  return {
+    ...b,
+    data: { initialUses: b.uses, ...(b.data || {}) },
+  };
+}

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -72,6 +72,10 @@ export class PlayScene extends Phaser.Scene {
 
     this.load.atlas('furniture', 'assets/sprites/furniture.png', 'assets/sprites/furniture.json');
 
+    Object.entries(ITEM_TEXTURE_PATHS).forEach(([key, path]) => {
+      this.load.image(key, path);
+    });
+
   }
 
   create() {


### PR DESCRIPTION
## Summary
- draw bright use dots under HUD inventory slots instead of use text
- track initial item uses so dots remove as items are consumed
- preload item textures during scene setup so sprites render correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da947ea7f083328c54ea9a0083941d