### PR TITLE
Fix player spritesheet slicing and animation indices

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -62,8 +62,8 @@ export class PlayScene extends Phaser.Scene {
 
   preload() {
     this.load.spritesheet('player', 'assets/sprites/player.png', {
-      frameWidth: 64,
-      frameHeight: 105,
+      frameWidth: 102,
+      frameHeight: 128,
     });
     this.load.spritesheet('monster', 'assets/sprites/monster.png', {
       frameWidth: 128,
@@ -125,7 +125,7 @@ export class PlayScene extends Phaser.Scene {
 
 
     // player
-    this.player = this.physics.add.sprite(200, 200, 'player', 16);
+    this.player = this.physics.add.sprite(200, 200, 'player', 8);
     this.player.setScale(0.5);
     const playerBody = this.player.body as Phaser.Physics.Arcade.Body;
     playerBody.setSize(28, 32);
@@ -1125,7 +1125,7 @@ export class PlayScene extends Phaser.Scene {
     if (!this.anims.exists('player-idle')) {
       this.anims.create({
         key: 'player-idle',
-        frames: this.anims.generateFrameNumbers('player', { frames: [16, 17, 18, 19] }),
+        frames: this.anims.generateFrameNumbers('player', { frames: [8, 9, 10, 11] }),
         frameRate: 6,
         repeat: -1,
       });
@@ -1134,7 +1134,7 @@ export class PlayScene extends Phaser.Scene {
     if (!this.anims.exists('player-walk')) {
       this.anims.create({
         key: 'player-walk',
-        frames: this.anims.generateFrameNumbers('player', { start: 16, end: 23 }),
+        frames: this.anims.generateFrameNumbers('player', { start: 8, end: 11 }),
         frameRate: 10,
         repeat: -1,
       });


### PR DESCRIPTION
## Summary
- update the player spritesheet slice dimensions to the actual 102x128 grid
- point the default frame and idle/walk animations at the corrected frame indices

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68da938ec3e08332b121c3f78c53a58a