### PR TITLE
Fix idle animation when characters stop moving

### DIFF
--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -589,7 +589,8 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
     }
 
     if (!this.actionLock && this.body) {
-      const moving = (this.body.velocity.lengthSq && this.body.velocity.lengthSq() > 16) || this.body.speed > 4;
+      const body = this.body as Phaser.Physics.Arcade.Body;
+      const moving = body.deltaAbsX() > 0.5 || body.deltaAbsY() > 0.5;
       this.anims.play(moving ? 'monster-walk' : 'monster-idle', true);
     }
 

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -1098,7 +1098,7 @@ export class PlayScene extends Phaser.Scene {
       if (this.cursors.down?.isDown) body.setVelocityY(speed);
     }
 
-    const moving = body.velocity.lengthSq() > 0;
+    const moving = body.deltaAbsX() > 0.5 || body.deltaAbsY() > 0.5;
     this.player.anims.play(moving ? 'player-walk' : 'player-idle', true);
 
     const overItem: GroundItem | null = (this as any)._overItem || null;


### PR DESCRIPTION
## Summary
- switch idle detection for the player to use Arcade physics deltas to avoid false walking animations
- apply the same movement delta check to the monster so it correctly reverts to idle when stationary

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da96a660708332b1942885da6705d2