### PR TITLE
Fix sprite sheet frame dimensions

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -63,11 +63,11 @@ export class PlayScene extends Phaser.Scene {
   preload() {
     this.load.spritesheet('player', 'assets/sprites/player.png', {
       frameWidth: 102,
-      frameHeight: 128,
+      frameHeight: 152,
     });
     this.load.spritesheet('monster', 'assets/sprites/monster.png', {
-      frameWidth: 128,
-      frameHeight: 128,
+      frameWidth: 184,
+      frameHeight: 275,
     });
 
     this.load.atlas('furniture', 'assets/sprites/furniture.png', 'assets/sprites/furniture.json');


### PR DESCRIPTION
## Summary
- adjust the player sprite sheet frame height to match the new artwork
- update the monster sprite sheet frame dimensions so animations no longer crop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da9962f9888332872b2c9f40290a1e