### PR TITLE
Adjust monster and player hitboxes for reliable contact

### DIFF
--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -541,7 +541,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
     scene.physics.add.existing(this);
     this.setScale(0.45);
     const body = this.body as Phaser.Physics.Arcade.Body;
-    body.setCircle(30, 34, 54);
+    body.setCircle(42, 22, 42);
     this.setCollideWorldBounds(true);
     this.anims.play('monster-idle');
     this.baseScale = { x: this.scaleX, y: this.scaleY };

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -132,8 +132,8 @@ export class PlayScene extends Phaser.Scene {
     this.player = this.physics.add.sprite(200, 200, 'player', 8);
     this.player.setScale(0.5);
     const playerBody = this.player.body as Phaser.Physics.Arcade.Body;
-    playerBody.setSize(28, 32);
-    playerBody.setOffset(18, 66);
+    playerBody.setSize(38, 48);
+    playerBody.setOffset(13, 50);
     playerBody.maxSpeed = 260;
     this.player.setCollideWorldBounds(true);
     this.player.setDepth(10);


### PR DESCRIPTION
## Summary
- widen and deepen the player's physics body so its hurtbox aligns with the sprite when attacking
- expand and recentre the monster's collision circle to make contact damage trigger consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da9bf6a4b88332a4056955d5298b3d