### PR TITLE
Set monster base HP to 12

### DIFF
--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -21,8 +21,8 @@ type TelegraphHandle = {
 };
 
 export class Monster extends Phaser.Physics.Arcade.Sprite {
-  hp = 12;
-  private hpMax = this.hp;
+  private hpMax = 12;
+  hp = this.hpMax;
   state: 'wander'|'chase'|'engage' = 'wander';
   actionT = { sweep: 2.5, smash: 4.0, rush: 5.0, roar: 7.0 };
   cd = { sweep: 0, smash: 0, rush: 0, roar: 0 };


### PR DESCRIPTION
## Summary
- set the monster's base HP to 12 via a shared hpMax field so future resets stay consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daaf15f1f48332b1859475b1301193