### PR TITLE
Fix sprite direction animation mapping

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -1151,8 +1151,8 @@ export class PlayScene extends Phaser.Scene {
     const playerDirections: Record<'up' | 'down' | 'left' | 'right', number> = {
       up: 0,
       down: 1,
-      right: 2,
-      left: 3,
+      right: 3,
+      left: 2,
     };
 
     Object.entries(playerDirections).forEach(([dir, row]) => {
@@ -1173,8 +1173,8 @@ export class PlayScene extends Phaser.Scene {
 
     const monsterDirections: Record<'up' | 'down' | 'left' | 'right', number> = {
       down: 0,
-      left: 1,
-      right: 2,
+      left: 2,
+      right: 1,
       up: 3,
     };
 


### PR DESCRIPTION
## Summary
- swap the player animation rows for left and right movement to match the art
- adjust the monster animation mappings so horizontal movement faces the correct way

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68daaf1b16188332a549dd5da8d8a9f2