### PR TITLE
Fix yoyo spawn overlapping with rug collider

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -48,7 +48,7 @@ export class PlayScene extends Phaser.Scene {
     { x: 640, y: 200 },
     { x: 780, y: 320 },
     { x: 420, y: 640 },
-    { x: 860, y: 640 },
+    { x: 860, y: 596 },
   ];
   private restockPool: Item['id'][] = ['knife', 'bottle', 'soda', 'match', 'bandaid', 'yoyo'];
   private furniture: SearchableFurniture[] = [];
@@ -180,7 +180,7 @@ export class PlayScene extends Phaser.Scene {
     this.createGroundItem(640, 200, 'soda');
     this.createGroundItem(780, 320, 'match');
     this.createGroundItem(420, 640, 'bandaid');
-    this.createGroundItem(860, 640, 'yoyo');
+    this.createGroundItem(860, 596, 'yoyo');
 
     this.time.addEvent({
       delay: 15000,


### PR DESCRIPTION
## Summary
- move the yoyo restock point and initial spawn off the rug collider so it can be collected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daaf4baa208332afcd3d7fc9f68471