### PR TITLE
Normalize physics bodies for scaled sprites

### DIFF
--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -787,7 +787,16 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
     scene.physics.add.existing(this);
     this.setScale(0.45);
     const body = this.body as Phaser.Physics.Arcade.Body;
-    body.setCircle(42, 22, 42);
+    const monsterScaleX = Math.abs(this.scaleX) || 1;
+    const monsterScaleY = Math.abs(this.scaleY) || 1;
+    const monsterBodyRadius = 42;
+    const monsterBodyOffsetX = 22;
+    const monsterBodyOffsetY = 42;
+    body.setCircle(
+      monsterBodyRadius / monsterScaleX,
+      monsterBodyOffsetX / monsterScaleX,
+      monsterBodyOffsetY / monsterScaleY,
+    );
     this.setCollideWorldBounds(true);
     this.playMovementAnimation(false);
     this.baseScale = { x: this.scaleX, y: this.scaleY };

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -221,8 +221,14 @@ export class PlayScene extends Phaser.Scene {
     this.player = this.physics.add.sprite(200, 200, 'player', 8);
     this.player.setScale(0.5);
     const playerBody = this.player.body as Phaser.Physics.Arcade.Body;
-    playerBody.setSize(38, 48);
-    playerBody.setOffset(13, 50);
+    const playerScaleX = Math.abs(this.player.scaleX) || 1;
+    const playerScaleY = Math.abs(this.player.scaleY) || 1;
+    const playerBodyWidth = 38;
+    const playerBodyHeight = 48;
+    const playerBodyOffsetX = 13;
+    const playerBodyOffsetY = 50;
+    playerBody.setSize(playerBodyWidth / playerScaleX, playerBodyHeight / playerScaleY);
+    playerBody.setOffset(playerBodyOffsetX / playerScaleX, playerBodyOffsetY / playerScaleY);
     playerBody.maxSpeed = 260;
     this.player.setCollideWorldBounds(true);
     this.player.setDepth(10);


### PR DESCRIPTION
## Summary
- normalize the player collider dimensions based on its render scale
- apply the same world-space normalization to the monster's collision circle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daef5605208332aaa5f23c0954035d