### PR TITLE
Remove rug furniture from play scene

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -249,22 +249,6 @@ export class PlayScene extends Phaser.Scene {
         offsetX: 1.5,
       },
     });
-    this.addFurnitureBlock(furniture, 640, 360, {
-      sprite: {
-        frame: 'rug',
-        offsetY: -20,
-        depth: 1,
-        scaleX: 1.45,
-        scaleY: 1,
-      },
-      hitbox: {
-        width: 213,
-        height: 60,
-        offsetY: -32,
-      },
-    }); // rug edge (as blocker for proto)
-
-
     // player
     this.player = this.physics.add.sprite(200, 200, 'player', 8);
     this.player.setScale(0.5);


### PR DESCRIPTION
## Summary
- remove the rug furniture block so it no longer appears on the map

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafb2b43648332915da9f395849125