### PR TITLE
Fix player vertical walk animation direction

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -1663,9 +1663,13 @@ export class PlayScene extends Phaser.Scene {
         frameRate: 1,
         repeat: -1,
       });
+      const walkFrames = this.anims
+        .generateFrameNumbers('player', { start: base, end: base + 3 })
+        .slice();
+      const adjustedWalkFrames = dir === 'up' || dir === 'down' ? walkFrames.reverse() : walkFrames;
       ensureAnimation(`player-walk-${dir}`, {
         key: `player-walk-${dir}`,
-        frames: this.anims.generateFrameNumbers('player', { start: base, end: base + 3 }),
+        frames: adjustedWalkFrames,
         frameRate: 10,
         repeat: -1,
       });


### PR DESCRIPTION
## Summary
- reverse the frame order for the player's up and down walk animations so they play correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbcc75e5d88332868c0eb6e96c3aee