### PR TITLE
Fix monster furniture pushing

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -377,7 +377,7 @@ export class PlayScene extends Phaser.Scene {
     const body = rect.body as Phaser.Physics.Arcade.Body;
     body.setAllowGravity(false);
     body.setImmovable(false);
-    body.pushable = false;
+    body.pushable = true;
     body.setMass(4);
     body.setDamping(true);
     body.setDrag(220, 220);


### PR DESCRIPTION
## Summary
- allow furniture hitboxes to remain dynamic by enabling Arcade Physics pushing so the monster can move them

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbd5e942248332978c414da871382c