### PR TITLE
Burst monster into the bedroom from the right edge

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -371,8 +371,11 @@ export class PlayScene extends Phaser.Scene {
     this.physics.add.collider(furniture, furniture);
 
     // monster
-    this.monster = new Monster(this, 1100, 680);
+    const monsterSpawnX = ROOM_W + 120;
+    const monsterSpawnY = ROOM_H / 2;
+    this.monster = new Monster(this, monsterSpawnX, monsterSpawnY);
     this.monster.setDepth(10);
+    this.monster.startSpawnBurst({ x: -1, y: 0 }, 900, 0.3);
     this.physics.add.collider(
       this.monster,
       furniture,


### PR DESCRIPTION
## Summary
- spawn the monster just outside the middle of the room's right wall
- add a short-lived spawn burst so the monster shoots into the room before resuming AI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd172c2550833283a93223a596740d