### PR TITLE
Fix monster walking scale to prevent flicker when stuck

### DIFF
--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -976,7 +976,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
       const speed = body.velocity.length() || 0;
       if (speed > 40) {
         this.idleTween?.pause();
-        this.setScale(1.05, 0.95);
+        this.setScale(this.baseScale.x * 1.05, this.baseScale.y * 0.95);
       } else if (!this.currentChain) {
         this.resetPose();
         this.idleTween?.resume();


### PR DESCRIPTION
## Summary
- adjust the monster's movement scaling to stay relative to its base size and avoid rapid flickering when its speed fluctuates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd18de33b483329799bf4348e31013