### PR TITLE
Fix swapped player vertical animations

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -1986,8 +1986,8 @@ export class PlayScene extends Phaser.Scene {
     };
 
     const playerDirections: Record<'up' | 'down' | 'left' | 'right', number> = {
-      up: 0,
-      down: 1,
+      down: 0,
+      up: 1,
       right: 3,
       left: 2,
     };


### PR DESCRIPTION
## Summary
- correct the player sprite sheet row mapping so the up and down walk animations play in the right direction

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd1c88e8988332a76a2b64777cb84f