### PR TITLE
Reposition bottom-left bed between the top beds

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -162,9 +162,9 @@ export class PlayScene extends Phaser.Scene {
         offsetY: 0,
       },
     });
-    this.addFurnitureBlock(furniture, 330, 520, {
+    this.addFurnitureBlock(furniture, 640, 200, {
       searchable: true,
-      name: 'Left Lower Bed',
+      name: 'Middle Upper Bed',
       searchDuration: 2600,
       checkPoints: [0.85, 0.55, 0.25],
       findChance: 0.5,


### PR DESCRIPTION
## Summary
- move the former bottom-left bed to sit between the two top beds
- rename the furniture entry to reflect its new top-middle location

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd1db79ba483328b80cd4dbe8e57e2