### PR TITLE
Increase monster sprite size

### DIFF
--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -905,7 +905,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
     super(scene, x, y, 'monster', 0);
     scene.add.existing(this);
     scene.physics.add.existing(this);
-    this.setScale(0.45);
+    this.setScale(0.9);
     const body = this.body as Phaser.Physics.Arcade.Body;
     const monsterBodyWidth = Math.abs(this.displayWidth) || Math.abs(this.width);
     const monsterBodyHeight = Math.abs(this.displayHeight) || Math.abs(this.height);


### PR DESCRIPTION
## Summary
- double the monster sprite scale so the in-game character appears twice as large
- rely on the existing hitbox scaling to expand physics interactions alongside the sprite

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd2574884083328c159ff6c2f0a2f0