### PR TITLE
Improve combat feedback with hitstop, SFX, and burning slow

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -2,13 +2,15 @@ import Phaser from 'phaser';
 import { ROOM_W, ROOM_H, PLAYER_BASE } from '@game/config';
 import type { Item } from '@game/types';
 import { ITEM_TEXTURE_PATHS } from '@game/items';
-import { Monster, type TelegraphImpact } from '@game/monster';
+import { Monster, type TelegraphImpact, type MonsterHitbox } from '@game/monster';
 import { createHUD, drawHUD, type HudElements } from '@ui/hud';
 import { InputSystem } from '../systems/InputSystem';
 import { InventorySystem, type GroundItem } from '../systems/InventorySystem';
 import { SpawnerSystem } from '../systems/SpawnerSystem';
 import { SearchSystem, type SpawnEmojiFn } from '../systems/SearchSystem';
-import { TelegraphSystem } from '../systems/TelegraphSystem';
+import { TelegraphSystem, type MonsterDamageEvent } from '../systems/TelegraphSystem';
+
+type TelegraphSfxKey = 'whoosh' | 'rise' | 'crack' | 'thud';
 import { BEDROOM_FURNITURE_LAYOUT } from '../systems/furnitureLayout';
 
 export class PlayScene extends Phaser.Scene {
@@ -32,6 +34,14 @@ export class PlayScene extends Phaser.Scene {
   private playerKnockbackUntil = 0;
   private playerShoveCooldownUntil = 0;
   private readonly playerShoveCooldown = 8000;
+  private hitstopUntil = 0;
+  private hitstopActive = false;
+  private storedPlayerVelocity = new Phaser.Math.Vector2();
+  private storedMonsterVelocity = new Phaser.Math.Vector2();
+  private pendingPostHitstop: (() => void)[] = [];
+  private playerBlinkEvent?: Phaser.Time.TimerEvent;
+  private playerAnimPausedByHitstop = false;
+  private monsterAnimPausedByHitstop = false;
   constructor() { super('Play'); }
 
   preload() {
@@ -132,15 +142,6 @@ export class PlayScene extends Phaser.Scene {
       undefined,
       this.searchSystem,
     );
-    this.physics.add.overlap(this.monster, this.player, () => {
-      if (this.time.now < this.playerIFrameUntil) return;
-      if (!(this.player as any)._lastHit || this.time.now - (this.player as any)._lastHit > 1000) {
-        (this.player as any)._lastHit = this.time.now;
-        this.damagePlayer(1);
-        this.playerIFrameUntil = this.time.now + 150;
-      }
-    });
-
     this.telegraphSystem = new TelegraphSystem(
       this,
       this.player,
@@ -152,7 +153,11 @@ export class PlayScene extends Phaser.Scene {
         this.resetPlayerState();
         this.scene.restart();
       },
+      (event) => this.handleMonsterDamaged(event),
     );
+
+    this.events.on('play-sfx', this.playStubSfx, this);
+    this.events.once('shutdown', () => this.events.off('play-sfx', this.playStubSfx, this));
 
     const starterItems: Item['id'][] = [
       'knife',
@@ -320,7 +325,15 @@ export class PlayScene extends Phaser.Scene {
     this.telegraphSystem.showThrowTelegraph(range, color, emoji, fire ? 520 : 420, laneHalfWidth * 2, tailEmoji);
     const hits = this.telegraphSystem.getMonsterHitboxesWithinLane(range, laneHalfWidth);
     if (hits.length) {
-      this.telegraphSystem.hitMonster(dmg, fire ? '🔥' : stun ? '💫' : '💥', hits);
+      const upfrontDamage = fire ? 1 : dmg;
+      const dealt = this.telegraphSystem.hitMonster(upfrontDamage, fire ? '🔥' : stun ? '💫' : '💥', hits);
+      if (fire && dealt > 0) {
+        this.monster.applyBurning(4000);
+        const remainingBase = Math.max(dmg - upfrontDamage, 0);
+        if (remainingBase > 0) {
+          this.applyBurningDamage(remainingBase, hits);
+        }
+      }
       if (stun) this.monster.setVelocity(0, 0);
     }
   }
@@ -329,17 +342,200 @@ export class PlayScene extends Phaser.Scene {
     this.inventorySystem.gainBottle(slot, this.player.x + 8, this.player.y + 8);
   }
 
-  damagePlayer(n: number, options: { shake?: { duration: number; intensity: number } } = {}) {
+  damagePlayer(
+    n: number,
+    options: { shake?: { duration: number; intensity: number }; isDot?: boolean } = {},
+  ) {
     if (n <= 0) return;
     const shake = options.shake ?? { duration: 80, intensity: 0.004 };
-    if (shake) {
+    const isDot = Boolean(options.isDot);
+    if (shake && !isDot) {
       this.cameras.main.shake(shake.duration, shake.intensity);
     }
+    if (!isDot) {
+      this.startHitstop(Phaser.Math.Between(60, 90));
+    }
+    this.startPlayerIFrames(150);
+    if (!isDot) {
+      this.events.emit('play-sfx', 'thud');
+    }
+    this.spawnDamageNumber(this.player.x, this.player.y - 24, n, { isDot });
     this.hp -= n;
     if (this.hp <= 0) {
       this.resetPlayerState();
       this.scene.restart();
     }
+  }
+
+  private playStubSfx(key: TelegraphSfxKey) {
+    if (this.sound.locked) return;
+    const existing = this.sound.get(key);
+    if (existing) {
+      existing.play();
+      return;
+    }
+    console.debug?.(`[sfx:${key}]`);
+  }
+
+  private handleMonsterDamaged(event: MonsterDamageEvent) {
+    if (!event || event.damage <= 0) return;
+    if (!event.isDot) {
+      this.startHitstop(Phaser.Math.Between(40, 70));
+      this.events.emit('play-sfx', 'thud');
+    }
+  }
+
+  private startHitstop(duration: number) {
+    if (duration <= 0) return;
+    const now = this.time.now;
+    this.hitstopUntil = Math.max(this.hitstopUntil, now + duration);
+    if (this.hitstopActive) {
+      return;
+    }
+    this.hitstopActive = true;
+
+    const playerBody = this.player.body as Phaser.Physics.Arcade.Body | undefined;
+    if (playerBody) {
+      this.storedPlayerVelocity.set(playerBody.velocity.x, playerBody.velocity.y);
+      playerBody.setVelocity(0, 0);
+      playerBody.moves = false;
+    }
+    this.playerAnimPausedByHitstop = Boolean(this.player.anims.isPlaying);
+    if (this.playerAnimPausedByHitstop) {
+      this.player.anims.pause();
+    }
+
+    const monsterBody = this.monster.body as Phaser.Physics.Arcade.Body | undefined;
+    if (monsterBody) {
+      this.storedMonsterVelocity.set(monsterBody.velocity.x, monsterBody.velocity.y);
+      monsterBody.setVelocity(0, 0);
+      monsterBody.moves = false;
+    }
+    this.monsterAnimPausedByHitstop = Boolean(this.monster.anims.isPlaying);
+    if (this.monsterAnimPausedByHitstop) {
+      this.monster.anims.pause();
+    }
+  }
+
+  private endHitstop(skipTasks = false) {
+    if (!this.hitstopActive) {
+      this.hitstopUntil = 0;
+      if (skipTasks) this.pendingPostHitstop.length = 0;
+      return;
+    }
+
+    this.hitstopActive = false;
+    this.hitstopUntil = 0;
+
+    const playerBody = this.player.body as Phaser.Physics.Arcade.Body | undefined;
+    if (playerBody) {
+      playerBody.moves = true;
+      playerBody.setVelocity(this.storedPlayerVelocity.x, this.storedPlayerVelocity.y);
+    }
+    if (this.playerAnimPausedByHitstop && this.player.anims.currentAnim) {
+      this.player.anims.resume();
+    }
+    this.playerAnimPausedByHitstop = false;
+
+    const monsterBody = this.monster.body as Phaser.Physics.Arcade.Body | undefined;
+    if (monsterBody) {
+      monsterBody.moves = true;
+      monsterBody.setVelocity(this.storedMonsterVelocity.x, this.storedMonsterVelocity.y);
+    }
+    if (this.monsterAnimPausedByHitstop && this.monster.anims.currentAnim) {
+      this.monster.anims.resume();
+    }
+    this.monsterAnimPausedByHitstop = false;
+
+    const tasks = this.pendingPostHitstop.splice(0);
+    if (!skipTasks) {
+      tasks.forEach((fn) => fn());
+    } else {
+      this.pendingPostHitstop.length = 0;
+    }
+  }
+
+  private queueAfterHitstop(callback: () => void) {
+    if (this.hitstopActive) {
+      this.pendingPostHitstop.push(callback);
+    } else {
+      callback();
+    }
+  }
+
+  private startPlayerIFrames(duration = 150) {
+    const now = this.time.now;
+    this.playerIFrameUntil = Math.max(this.playerIFrameUntil, now + duration);
+
+    if (this.playerBlinkEvent) {
+      this.playerBlinkEvent.destroy();
+      this.playerBlinkEvent = undefined;
+    }
+
+    this.player.setAlpha(0.45);
+    this.playerBlinkEvent = this.time.addEvent({
+      delay: 50,
+      loop: true,
+      callback: () => {
+        if (this.time.now >= this.playerIFrameUntil) {
+          this.player.setAlpha(1);
+          this.playerBlinkEvent?.destroy();
+          this.playerBlinkEvent = undefined;
+          return;
+        }
+        const isDim = this.player.alpha > 0.8;
+        this.player.setAlpha(isDim ? 0.45 : 1);
+      },
+    });
+  }
+
+  private spawnDamageNumber(
+    x: number,
+    y: number,
+    amount: number,
+    options: { tint?: number; isDot?: boolean } = {},
+  ) {
+    const label = this.add
+      .text(x, y, `-${Math.round(amount)}`, {
+        fontSize: '14px',
+        fontStyle: 'bold',
+      })
+      .setOrigin(0.5)
+      .setDepth(this.fxDepth + 3)
+      .setScale(0.9);
+
+    const tint = options.isDot ? 0xffb066 : options.tint ?? 0xff5f5f;
+    label.setTint(tint);
+
+    this.tweens.add({
+      targets: label,
+      y: y - 20,
+      alpha: { from: 1, to: 0 },
+      duration: options.isDot ? 500 : 360,
+      ease: 'Sine.easeOut',
+      onComplete: () => label.destroy(),
+    });
+  }
+
+  private applyBurningDamage(totalBaseDamage: number, hitboxes: MonsterHitbox[]) {
+    if (totalBaseDamage <= 0) return;
+    const ticks = Math.max(1, Math.round(totalBaseDamage));
+    const perTickBase = totalBaseDamage / ticks;
+    for (let i = 1; i <= ticks; i++) {
+      this.time.delayedCall(450 * i, () => {
+        if (!this.monster.active || this.monster.hp <= 0) return;
+        this.telegraphSystem.hitMonster(perTickBase, '🔥', hitboxes, { isDot: true });
+      });
+    }
+  }
+
+  private applyKnockbackImpulse(strength: number) {
+    if (strength <= 0) return;
+    const body = this.player.body as Phaser.Physics.Arcade.Body;
+    const angle = Phaser.Math.Angle.Between(this.monster.x, this.monster.y, this.player.x, this.player.y);
+    const velocity = this.physics.velocityFromRotation(angle, strength);
+    body.setVelocity(velocity.x, velocity.y);
+    this.playerKnockbackUntil = this.time.now + 220;
   }
 
   private applyMonsterImpact(impact: TelegraphImpact) {
@@ -366,11 +562,8 @@ export class PlayScene extends Phaser.Scene {
   }
 
   private applyKnockback(strength: number) {
-    const body = this.player.body as Phaser.Physics.Arcade.Body;
-    const angle = Phaser.Math.Angle.Between(this.monster.x, this.monster.y, this.player.x, this.player.y);
-    const velocity = this.physics.velocityFromRotation(angle, strength);
-    body.setVelocity(velocity.x, velocity.y);
-    this.playerKnockbackUntil = this.time.now + 160;
+    if (strength <= 0) return;
+    this.queueAfterHitstop(() => this.applyKnockbackImpulse(strength));
   }
 
   speedBoost(ms: number) {
@@ -395,6 +588,21 @@ export class PlayScene extends Phaser.Scene {
     this.playerKnockbackUntil = 0;
     this.playerShoveCooldownUntil = 0;
     this.overItem = null;
+    if (this.hitstopActive) {
+      this.endHitstop(true);
+    } else {
+      this.hitstopUntil = 0;
+      this.pendingPostHitstop.length = 0;
+      const playerBody = this.player.body as Phaser.Physics.Arcade.Body | undefined;
+      const monsterBody = this.monster?.body as Phaser.Physics.Arcade.Body | undefined;
+      if (playerBody) playerBody.moves = true;
+      if (monsterBody) monsterBody.moves = true;
+    }
+    if (this.playerBlinkEvent) {
+      this.playerBlinkEvent.destroy();
+      this.playerBlinkEvent = undefined;
+    }
+    this.player.setAlpha(1);
     this.inputSystem?.reset();
     if (this.player?.body) {
       (this.player.body as Phaser.Physics.Arcade.Body).maxSpeed = 260;
@@ -421,6 +629,10 @@ export class PlayScene extends Phaser.Scene {
   update(time: number, delta: number) {
     const body = this.player.body as Phaser.Physics.Arcade.Body;
     const now = this.time.now;
+    if (this.hitstopActive && now >= this.hitstopUntil) {
+      this.endHitstop();
+    }
+
     if (now >= this.playerSpeedBoostUntil && this.playerSpeedBoostMultiplier !== 1) {
       this.playerSpeedBoostMultiplier = 1;
       body.maxSpeed = 260;
@@ -432,13 +644,15 @@ export class PlayScene extends Phaser.Scene {
     if (now < this.playerSlowUntil) {
       speedMultiplier *= this.playerSlowFactor;
     }
-    const speed = 260 * speedMultiplier;
+    const baseSpeed = 260 * speedMultiplier;
+    const hitstopActive = this.hitstopActive;
+    const speed = hitstopActive ? 0 : baseSpeed;
     const knockbackActive = now < this.playerKnockbackUntil;
 
     const inputResult = this.inputSystem.update(this.player, {
       speed,
       searching: this.searchSystem.isSearching(),
-      knockbackActive,
+      knockbackActive: knockbackActive || hitstopActive,
     });
 
     if (this.overItem && (!this.overItem.active || !this.physics.overlap(this.player, this.overItem as any))) {
@@ -449,7 +663,9 @@ export class PlayScene extends Phaser.Scene {
     this.searchSystem.updateFurnitureVisuals();
     this.searchSystem.updateSearch(delta, this.player);
 
-    this.monster.update(delta / 1000, this.player);
+    if (!hitstopActive) {
+      this.monster.update(delta / 1000, this.player);
+    }
     this.playerIFrameUntil = this.telegraphSystem.resolveTelegraphCollisions(
       now,
       this.playerIFrameUntil,

--- a/src/systems/InputSystem.ts
+++ b/src/systems/InputSystem.ts
@@ -79,7 +79,10 @@ export class InputSystem {
     const body = player.body as Phaser.Physics.Arcade.Body;
 
     if (options.knockbackActive) {
-      body.velocity.scale(0.9);
+      body.velocity.scale(0.82);
+      if (body.velocity.lengthSq() < 36) {
+        body.setVelocity(0, 0);
+      }
     } else {
       body.setVelocity(0, 0);
     }


### PR DESCRIPTION
## Summary
- add hitstop control, player blink i-frames, and impact SFX routing for monster telegraphs
- show floating damage numbers (with DoT tint) and queue post-hit knockback/slow effects during hitstop
- hook fire bottle burning to slow the monster, schedule burn DoT ticks, and tighten knockback friction decay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd45e75dc48332846ae217772373bd