### PR TITLE
Update crafting recipes to use symmetric lookup

### DIFF
--- a/src/game/recipes.ts
+++ b/src/game/recipes.ts
@@ -3,15 +3,26 @@ import type { ItemId } from './items';
 export type Recipe = { a: ItemId; b: ItemId; out: ItemId };
 
 export const RECIPES: Recipe[] = [
+  { a: 'bandaid', b: 'match', out: 'smoke_patch' },
+  { a: 'bandaid', b: 'soda', out: 'adrenal_patch' },
+  { a: 'bottle', b: 'knife', out: 'glass_shiv' },
   { a: 'bottle', b: 'match', out: 'fire_bottle' },
-  { a: 'yoyo',   b: 'knife', out: 'bladed_yoyo' },
-  { a: 'knife',  b: 'bottle', out: 'glass_shiv' },
-  { a: 'match',  b: 'bandaid', out: 'smoke_patch' },
-  { a: 'soda',   b: 'bandaid', out: 'adrenal_patch' },
-  { a: 'soda',   b: 'match', out: 'fizz_bomb' },
+  { a: 'match', b: 'soda', out: 'fizz_bomb' },
+  { a: 'knife', b: 'yoyo', out: 'bladed_yoyo' },
 ];
 
-export function craft(a: ItemId, b: ItemId): ItemId | null {
-  const r = RECIPES.find(r => (r.a === a && r.b === b) || (r.a === b && r.b === a));
-  return r ? r.out : null;
+const RECIPE_LOOKUP = RECIPES.reduce<Map<string, ItemId>>((acc, recipe) => {
+  const key = createKey(recipe.a, recipe.b);
+  acc.set(key, recipe.out);
+  return acc;
+}, new Map());
+
+function createKey(a: ItemId, b: ItemId) {
+  return [a, b].sort().join('::');
+}
+
+export function craft(a?: ItemId | null, b?: ItemId | null): ItemId | null {
+  if (!a || !b) return null;
+  const key = createKey(a, b);
+  return RECIPE_LOOKUP.get(key) ?? null;
 }

--- a/src/systems/InventorySystem.ts
+++ b/src/systems/InventorySystem.ts
@@ -85,7 +85,6 @@ export class InventorySystem {
   craft() {
     const first = this.inventory[0]?.id;
     const second = this.inventory[1]?.id;
-    if (!first || !second) return false;
     const result = craftRecipe(first, second);
     if (!result) return false;
     this.inventory[0] = { ...cloneItem(result) };

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -188,18 +188,13 @@ export function drawHUD(
   setPill(slotPills[1], inv[1]);
 
   // Craft preview pill (top-center) — only if recipe exists
-  let showCraft = false;
-  if (inv[0]?.id && inv[1]?.id) {
-    const outId = craft(inv[0].id, inv[1].id);
-    if (outId) {
-      const def = ITEMS[outId];
-      if (def) {
-        const fakeItem = cloneItem(outId);
-        setIcon(craftPreview.icon, fakeItem);
-        craftPreview.name.setText(def.label ? `Craft: ${def.label}` : 'Craft');
-        showCraft = true;
-      }
-    }
+  const outId = craft(inv[0]?.id ?? null, inv[1]?.id ?? null);
+  const def = outId ? ITEMS[outId] : undefined;
+  const showCraft = Boolean(def);
+  if (def) {
+    const fakeItem = cloneItem(outId);
+    setIcon(craftPreview.icon, fakeItem);
+    craftPreview.name.setText(def.label ? `Craft: ${def.label}` : 'Craft');
   }
   craftPreview.show(showCraft);
 


### PR DESCRIPTION
## Summary
- update the crafting recipe list to match the room-focused spec
- add a symmetric lookup map so `craft` works with unordered, optional inputs
- make the HUD preview and inventory crafting tolerate missing slots and null results

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6d6bfdb48332b4425a7afdb05dc7