### PR TITLE
Add house flow data with key and door management systems

### DIFF
--- a/src/content/rooms.ts
+++ b/src/content/rooms.ts
@@ -1,10 +1,10 @@
 import type { ItemId } from '@game/types';
+import type { RoomId } from '@game/world';
 import type { MonsterId } from '@content/monsters';
 import type { FurnitureLayoutEntry } from '../systems/SearchSystem';
 
 export type Weighted<T> = { id: T; weight: number };
-
-export type RoomId = 'hallway' | 'infirmary' | 'office' | 'kitchen' | 'entrance';
+export type { RoomId };
 
 export type SpawnPacing = {
   restockIntervalMs: number;

--- a/src/game/doors.ts
+++ b/src/game/doors.ts
@@ -1,0 +1,170 @@
+import Phaser from 'phaser';
+import { consumeKey, hasKey } from './keys';
+import { listRoomDoors, type DoorDefinition, type RoomId } from './world';
+
+const OPEN_DOORS = new Set<string>();
+
+export function resetDoors() {
+  OPEN_DOORS.clear();
+}
+
+export type DoorSystemOptions = {
+  onDoorOpened?: (door: DoorDefinition) => void;
+};
+
+type DoorInstance = {
+  def: DoorDefinition;
+  sprite: Phaser.GameObjects.Sprite;
+  zone: Phaser.GameObjects.Zone;
+  tooltip: Phaser.GameObjects.Text;
+  opened: boolean;
+  playerNear: boolean;
+  baseTooltipColor: string;
+};
+
+const TOOLTIP_STYLE = {
+  fontFamily: 'monospace',
+  fontSize: '12px',
+  color: '#f2f2f2',
+  backgroundColor: '#101820d8',
+  padding: { left: 6, right: 6, top: 2, bottom: 2 },
+  align: 'center',
+} as const;
+
+export class DoorSystem {
+  private doors: DoorInstance[] = [];
+  private playerRect = new Phaser.Geom.Rectangle();
+  private zoneRect = new Phaser.Geom.Rectangle();
+
+  constructor(
+    private readonly scene: Phaser.Scene,
+    private readonly player: Phaser.Physics.Arcade.Sprite,
+    private readonly options: DoorSystemOptions = {},
+  ) {}
+
+  destroy() {
+    this.clearDoors();
+  }
+
+  setRoom(roomId: RoomId) {
+    this.clearDoors();
+    const doorDefs = listRoomDoors(roomId);
+    doorDefs.forEach((def) => this.spawnDoor(def));
+  }
+
+  update() {
+    const body = this.player.body as Phaser.Physics.Arcade.Body | null;
+    if (!body) return;
+    this.playerRect.setTo(body.x, body.y, body.width, body.height);
+
+    for (const instance of this.doors) {
+      const zoneBody = instance.zone.body as Phaser.Physics.Arcade.StaticBody | undefined;
+      if (!zoneBody) continue;
+      this.zoneRect.setTo(zoneBody.x, zoneBody.y, zoneBody.width, zoneBody.height);
+      const overlapping = Phaser.Geom.Intersects.RectangleToRectangle(this.playerRect, this.zoneRect);
+      if (overlapping) {
+        this.showTooltip(instance);
+        instance.playerNear = true;
+      } else if (instance.playerNear) {
+        instance.playerNear = false;
+        instance.tooltip.setVisible(false);
+      }
+    }
+  }
+
+  tryInteract(): boolean {
+    const activeDoor = this.doors.find((door) => door.playerNear);
+    if (!activeDoor) return false;
+
+    if (!activeDoor.opened) {
+      const requirement = activeDoor.def.requirement;
+      if (requirement) {
+        if (!hasKey(requirement.key)) {
+          this.flashLocked(activeDoor);
+          return false;
+        }
+        consumeKey(requirement.key);
+      }
+      activeDoor.opened = true;
+      OPEN_DOORS.add(activeDoor.def.id);
+      this.scene.tweens.add({
+        targets: activeDoor.sprite,
+        alpha: { from: activeDoor.sprite.alpha, to: 0.7 },
+        duration: 160,
+        ease: 'Sine.easeOut',
+      });
+    }
+
+    this.options.onDoorOpened?.(activeDoor.def);
+    return true;
+  }
+
+  private spawnDoor(def: DoorDefinition) {
+    const { coords } = def;
+    const sprite = this.scene.add.sprite(coords.x, coords.y, def.sprite.key, def.sprite.frame);
+    sprite.setDepth(coords.depth ?? 5);
+
+    const hotspot = coords.hotspot ?? { width: 140, height: 200, offsetX: 0, offsetY: 0 };
+    const zone = this.scene.add.zone(coords.x + (hotspot.offsetX ?? 0), coords.y + (hotspot.offsetY ?? 0));
+    zone.setSize(hotspot.width, hotspot.height);
+    this.scene.physics.add.existing(zone, true);
+
+    const tooltip = this.scene.add
+      .text(
+        coords.x + (coords.tooltipOffset?.x ?? 0),
+        coords.y + (coords.tooltipOffset?.y ?? -120),
+        '',
+        TOOLTIP_STYLE,
+      )
+      .setOrigin(0.5)
+      .setVisible(false)
+      .setDepth((coords.depth ?? 5) + 1);
+
+    const opened = OPEN_DOORS.has(def.id);
+    if (opened) {
+      sprite.setAlpha(0.7);
+    }
+
+    this.doors.push({
+      def,
+      sprite,
+      zone,
+      tooltip,
+      opened,
+      playerNear: false,
+      baseTooltipColor: TOOLTIP_STYLE.color,
+    });
+  }
+
+  private clearDoors() {
+    this.doors.forEach((door) => {
+      door.sprite.destroy();
+      door.zone.destroy();
+      door.tooltip.destroy();
+    });
+    this.doors = [];
+  }
+
+  private showTooltip(door: DoorInstance) {
+    const requirement = door.def.requirement;
+    if (!door.opened && requirement && !hasKey(requirement.key)) {
+      door.tooltip.setColor('#ff8f8f');
+      door.tooltip.setText(`Locked: ${requirement.label}`);
+    } else {
+      door.tooltip.setColor(door.baseTooltipColor);
+      door.tooltip.setText(door.opened ? 'Press E to enter' : 'Press E to open');
+    }
+    door.tooltip.setVisible(true);
+  }
+
+  private flashLocked(door: DoorInstance) {
+    const requirement = door.def.requirement;
+    door.tooltip.setVisible(true);
+    door.tooltip.setColor('#ff8f8f');
+    door.tooltip.setText(`Locked: ${requirement?.label ?? 'Requires key'}`);
+    this.scene.time.delayedCall(360, () => {
+      if (!door.tooltip.active) return;
+      door.tooltip.setColor(door.baseTooltipColor);
+    });
+  }
+}

--- a/src/game/keys.ts
+++ b/src/game/keys.ts
@@ -1,0 +1,114 @@
+import type Phaser from 'phaser';
+import type { KeyId } from './world';
+
+export type KeyMetadata = {
+  id: KeyId;
+  label: string;
+  shortLabel: string;
+  color: number;
+};
+
+const KEY_METADATA: Record<KeyId, KeyMetadata> = {
+  nurse_badge: {
+    id: 'nurse_badge',
+    label: 'Nurse Badge',
+    shortLabel: 'NB',
+    color: 0x7dd6ff,
+  },
+  admin_badge: {
+    id: 'admin_badge',
+    label: 'Admin Badge',
+    shortLabel: 'AB',
+    color: 0xffcf73,
+  },
+  pantry_key: {
+    id: 'pantry_key',
+    label: 'Pantry Key',
+    shortLabel: 'PK',
+    color: 0xe88f52,
+  },
+  front_door_key: {
+    id: 'front_door_key',
+    label: 'Front Door Key',
+    shortLabel: 'FD',
+    color: 0xa0e076,
+  },
+};
+
+const KEY_ORDER: KeyId[] = ['nurse_badge', 'admin_badge', 'pantry_key', 'front_door_key'];
+
+export type KeyListener = (keys: KeyId[]) => void;
+
+const ownedKeys = new Set<KeyId>();
+const listeners = new Set<KeyListener>();
+
+function emitKeys() {
+  const snapshot = KEY_ORDER.filter((key) => ownedKeys.has(key));
+  listeners.forEach((listener) => listener([...snapshot]));
+}
+
+export function resetKeys() {
+  if (ownedKeys.size === 0) return;
+  ownedKeys.clear();
+  emitKeys();
+}
+
+export function grantKey(id: KeyId): boolean {
+  if (ownedKeys.has(id)) return false;
+  ownedKeys.add(id);
+  emitKeys();
+  return true;
+}
+
+export function hasKey(id: KeyId): boolean {
+  return ownedKeys.has(id);
+}
+
+export function consumeKey(id: KeyId): boolean {
+  if (!ownedKeys.has(id)) return false;
+  ownedKeys.delete(id);
+  emitKeys();
+  return true;
+}
+
+export function watchKeys(listener: KeyListener, emitCurrent = true): () => void {
+  listeners.add(listener);
+  if (emitCurrent) {
+    const snapshot = KEY_ORDER.filter((key) => ownedKeys.has(key));
+    listener([...snapshot]);
+  }
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getKeyMetadata(id: KeyId): KeyMetadata {
+  return KEY_METADATA[id];
+}
+
+export function renderKeyBadge(
+  scene: Phaser.Scene,
+  container: Phaser.GameObjects.Container,
+  key: KeyId,
+  index: number,
+  options: { width?: number; height?: number; gap?: number } = {},
+) {
+  const { width = 34, height = 18, gap = 6 } = options;
+  const meta = getKeyMetadata(key);
+  const root = scene.add.container(index * (width + gap), 0);
+  const bg = scene.add.graphics();
+  bg.fillStyle(meta.color, 0.9).fillRoundedRect(0, 0, width, height, 6);
+  bg.lineStyle(1, 0x101820, 0.85).strokeRoundedRect(0, 0, width, height, 6);
+
+  const label = scene.add.text(width / 2, height / 2, meta.shortLabel, {
+    fontFamily: 'monospace',
+    fontSize: '11px',
+    color: '#13171f',
+  });
+  label.setOrigin(0.5);
+
+  root.add([bg, label]);
+  container.add(root);
+}
+
+export { KEY_ORDER, KEY_METADATA };

--- a/src/game/world.ts
+++ b/src/game/world.ts
@@ -1,0 +1,183 @@
+export type RoomId = 'hallway' | 'infirmary' | 'office' | 'kitchen' | 'entrance';
+
+export type KeyId = 'nurse_badge' | 'admin_badge' | 'pantry_key' | 'front_door_key';
+
+export type DoorRequirement = { type: 'key'; key: KeyId; label: string };
+
+export type DoorHotspot = { width: number; height: number; offsetX?: number; offsetY?: number };
+
+export type DoorCoords = {
+  x: number;
+  y: number;
+  depth?: number;
+  hotspot?: DoorHotspot;
+  tooltipOffset?: { x: number; y: number };
+};
+
+export type DoorDefinition = {
+  /** Shared identifier so both sides of a doorway unlock together. */
+  id: string;
+  /** The room reached when the player walks through this doorway. */
+  target: RoomId;
+  sprite: { key: string; frame: string };
+  coords: DoorCoords;
+  requirement?: DoorRequirement;
+};
+
+export type RoomFlow = { id: RoomId; doors: DoorDefinition[] };
+
+const DOOR_SPRITE_ATLAS = 'doors_windows';
+
+const BASE_DEPTH = 5;
+
+const DOOR_COORDS = {
+  left: {
+    x: 210,
+    y: 372,
+    depth: BASE_DEPTH,
+    hotspot: { width: 150, height: 200, offsetX: 0, offsetY: -10 },
+    tooltipOffset: { x: 0, y: -140 },
+  },
+  right: {
+    x: 1070,
+    y: 372,
+    depth: BASE_DEPTH,
+    hotspot: { width: 150, height: 200, offsetX: 0, offsetY: -10 },
+    tooltipOffset: { x: 0, y: -140 },
+  },
+  north: {
+    x: 640,
+    y: 228,
+    depth: BASE_DEPTH,
+    hotspot: { width: 200, height: 180, offsetX: 0, offsetY: -20 },
+    tooltipOffset: { x: 0, y: -150 },
+  },
+  south: {
+    x: 640,
+    y: 580,
+    depth: BASE_DEPTH,
+    hotspot: { width: 220, height: 180, offsetX: 0, offsetY: -20 },
+    tooltipOffset: { x: 0, y: -150 },
+  },
+} as const satisfies Record<string, DoorCoords>;
+
+const REQUIREMENTS = {
+  nurseBadge: { type: 'key', key: 'nurse_badge', label: 'Nurse Badge' } as const,
+  adminBadge: { type: 'key', key: 'admin_badge', label: 'Admin Badge' } as const,
+  pantryKey: { type: 'key', key: 'pantry_key', label: 'Pantry Key' } as const,
+  frontDoorKey: { type: 'key', key: 'front_door_key', label: 'Front Door Key' } as const,
+};
+
+export const HOUSE_FLOW: RoomFlow[] = [
+  {
+    id: 'hallway',
+    doors: [
+      {
+        id: 'hallway_infirmary',
+        target: 'infirmary',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_infirmary' },
+        coords: DOOR_COORDS.left,
+      },
+      {
+        id: 'hallway_office',
+        target: 'office',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_office' },
+        coords: DOOR_COORDS.right,
+        requirement: REQUIREMENTS.nurseBadge,
+      },
+    ],
+  },
+  {
+    id: 'infirmary',
+    doors: [
+      {
+        id: 'hallway_infirmary',
+        target: 'hallway',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_hall' },
+        coords: DOOR_COORDS.right,
+      },
+      {
+        id: 'infirmary_office',
+        target: 'office',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_office' },
+        coords: DOOR_COORDS.left,
+        requirement: REQUIREMENTS.nurseBadge,
+      },
+      {
+        id: 'infirmary_kitchen',
+        target: 'kitchen',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_kitchen' },
+        coords: DOOR_COORDS.north,
+        requirement: REQUIREMENTS.pantryKey,
+      },
+    ],
+  },
+  {
+    id: 'office',
+    doors: [
+      {
+        id: 'hallway_office',
+        target: 'hallway',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_hall' },
+        coords: DOOR_COORDS.left,
+        requirement: REQUIREMENTS.nurseBadge,
+      },
+      {
+        id: 'infirmary_office',
+        target: 'infirmary',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_infirmary' },
+        coords: DOOR_COORDS.right,
+        requirement: REQUIREMENTS.nurseBadge,
+      },
+      {
+        id: 'office_kitchen',
+        target: 'kitchen',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_kitchen' },
+        coords: DOOR_COORDS.north,
+        requirement: REQUIREMENTS.adminBadge,
+      },
+    ],
+  },
+  {
+    id: 'kitchen',
+    doors: [
+      {
+        id: 'infirmary_kitchen',
+        target: 'infirmary',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_infirmary' },
+        coords: DOOR_COORDS.south,
+        requirement: REQUIREMENTS.pantryKey,
+      },
+      {
+        id: 'office_kitchen',
+        target: 'office',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_office' },
+        coords: DOOR_COORDS.left,
+        requirement: REQUIREMENTS.adminBadge,
+      },
+      {
+        id: 'kitchen_entrance',
+        target: 'entrance',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_entrance' },
+        coords: DOOR_COORDS.north,
+        requirement: REQUIREMENTS.frontDoorKey,
+      },
+    ],
+  },
+  {
+    id: 'entrance',
+    doors: [
+      {
+        id: 'kitchen_entrance',
+        target: 'kitchen',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_kitchen' },
+        coords: DOOR_COORDS.south,
+        requirement: REQUIREMENTS.frontDoorKey,
+      },
+    ],
+  },
+];
+
+export function listRoomDoors(roomId: RoomId): DoorDefinition[] {
+  return HOUSE_FLOW.find((entry) => entry.id === roomId)?.doors ?? [];
+}


### PR DESCRIPTION
## Summary
- define room/door flow metadata for the house and key identifiers the loader can consume
- implement a persistent key manager and expose HUD hooks to render key badges beneath the inventory slots
- add a door system that spawns door sprites per room, surfaces lock requirements, and consumes keys when doors are opened

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6ed425408332b3a9ce8c141c3d69