### PR TITLE
Refactor room flow with loader and verb-driven items

### DIFF
--- a/src/content/rooms.ts
+++ b/src/content/rooms.ts
@@ -11,6 +11,12 @@ export type SpawnPacing = {
   restockInitialDelayMs?: number;
 };
 
+export type RoomSpawns = {
+  restock: SpawnPacing;
+  items: Weighted<ItemId>[];
+  monsters: Weighted<MonsterId>[];
+};
+
 export type RoomConfig = {
   id: RoomId;
   size: { width: number; height: number };
@@ -18,9 +24,7 @@ export type RoomConfig = {
   furniture: FurnitureLayoutEntry[];
   restockPoints: { x: number; y: number }[];
   starterItems: ItemId[];
-  restockPool: Weighted<ItemId>[];
-  monsterWeights: Weighted<MonsterId>[];
-  spawnPacing: SpawnPacing;
+  spawns: RoomSpawns;
   keyDrops: Weighted<ItemId>[];
 };
 
@@ -676,9 +680,11 @@ export const ROOMS: Record<RoomId, RoomConfig> = {
     furniture: HALLWAY_FURNITURE,
     restockPoints: RESTOCK_POINTS.map((point) => ({ ...point })),
     starterItems: [...STARTER_ITEMS],
-    restockPool: RESTOCK_POOL.map((entry) => ({ ...entry })),
-    monsterWeights: MONSTER_WEIGHTS.map((entry) => ({ ...entry })),
-    spawnPacing: { ...SPAWN_PACING },
+    spawns: {
+      restock: { ...SPAWN_PACING },
+      items: RESTOCK_POOL.map((entry) => ({ ...entry })),
+      monsters: MONSTER_WEIGHTS.map((entry) => ({ ...entry })),
+    },
     keyDrops: [...EMPTY_KEY_DROPS],
   },
   infirmary: {
@@ -688,9 +694,11 @@ export const ROOMS: Record<RoomId, RoomConfig> = {
     furniture: INFIRMARY_FURNITURE,
     restockPoints: RESTOCK_POINTS.map((point) => ({ ...point })),
     starterItems: [...STARTER_ITEMS],
-    restockPool: RESTOCK_POOL.map((entry) => ({ ...entry })),
-    monsterWeights: MONSTER_WEIGHTS.map((entry) => ({ ...entry })),
-    spawnPacing: { ...SPAWN_PACING },
+    spawns: {
+      restock: { ...SPAWN_PACING },
+      items: RESTOCK_POOL.map((entry) => ({ ...entry })),
+      monsters: MONSTER_WEIGHTS.map((entry) => ({ ...entry })),
+    },
     keyDrops: [...EMPTY_KEY_DROPS],
   },
   office: {
@@ -700,9 +708,11 @@ export const ROOMS: Record<RoomId, RoomConfig> = {
     furniture: OFFICE_FURNITURE,
     restockPoints: RESTOCK_POINTS.map((point) => ({ ...point })),
     starterItems: [...STARTER_ITEMS],
-    restockPool: RESTOCK_POOL.map((entry) => ({ ...entry })),
-    monsterWeights: MONSTER_WEIGHTS.map((entry) => ({ ...entry })),
-    spawnPacing: { ...SPAWN_PACING },
+    spawns: {
+      restock: { ...SPAWN_PACING },
+      items: RESTOCK_POOL.map((entry) => ({ ...entry })),
+      monsters: MONSTER_WEIGHTS.map((entry) => ({ ...entry })),
+    },
     keyDrops: [...EMPTY_KEY_DROPS],
   },
   kitchen: {
@@ -712,9 +722,11 @@ export const ROOMS: Record<RoomId, RoomConfig> = {
     furniture: KITCHEN_FURNITURE,
     restockPoints: RESTOCK_POINTS.map((point) => ({ ...point })),
     starterItems: [...STARTER_ITEMS],
-    restockPool: RESTOCK_POOL.map((entry) => ({ ...entry })),
-    monsterWeights: MONSTER_WEIGHTS.map((entry) => ({ ...entry })),
-    spawnPacing: { ...SPAWN_PACING },
+    spawns: {
+      restock: { ...SPAWN_PACING },
+      items: RESTOCK_POOL.map((entry) => ({ ...entry })),
+      monsters: MONSTER_WEIGHTS.map((entry) => ({ ...entry })),
+    },
     keyDrops: [...EMPTY_KEY_DROPS],
   },
   entrance: {
@@ -724,9 +736,11 @@ export const ROOMS: Record<RoomId, RoomConfig> = {
     furniture: ENTRANCE_FURNITURE,
     restockPoints: RESTOCK_POINTS.map((point) => ({ ...point })),
     starterItems: [...STARTER_ITEMS],
-    restockPool: RESTOCK_POOL.map((entry) => ({ ...entry })),
-    monsterWeights: MONSTER_WEIGHTS.map((entry) => ({ ...entry })),
-    spawnPacing: { ...SPAWN_PACING },
+    spawns: {
+      restock: { ...SPAWN_PACING },
+      items: RESTOCK_POOL.map((entry) => ({ ...entry })),
+      monsters: MONSTER_WEIGHTS.map((entry) => ({ ...entry })),
+    },
     keyDrops: [...EMPTY_KEY_DROPS],
   },
 };

--- a/src/game/doors.ts
+++ b/src/game/doors.ts
@@ -9,7 +9,7 @@ export function resetDoors() {
 }
 
 export type DoorSystemOptions = {
-  onDoorOpened?: (door: DoorDefinition) => void;
+  onDoorOpened?: (door: DoorDefinition) => void | Promise<void>;
 };
 
 type DoorInstance = {

--- a/src/scenes/RoomLoader.ts
+++ b/src/scenes/RoomLoader.ts
@@ -1,0 +1,109 @@
+import Phaser from 'phaser';
+
+import { ROOMS, type RoomConfig, type RoomSpawns } from '@content/rooms';
+import type { ItemId } from '@game/items';
+import { DoorSystem } from '@game/doors';
+import type { Weighted } from '@content/rooms';
+import type { RoomId } from '@game/world';
+
+import { InventorySystem } from '../systems/InventorySystem';
+import { SearchSystem } from '../systems/SearchSystem';
+
+export type LoadedRoom = {
+  id: RoomId;
+  size: { width: number; height: number };
+  starterItems: ItemId[];
+  restockPoints: { x: number; y: number }[];
+  spawns: RoomSpawns;
+  keyDrops: Weighted<ItemId>[];
+};
+
+export class RoomLoader {
+  private background?: Phaser.GameObjects.Image;
+  private doorSystem?: DoorSystem;
+  private currentRoomId?: RoomId;
+
+  constructor(
+    private readonly scene: Phaser.Scene,
+    private readonly searchSystem: SearchSystem,
+    private readonly inventorySystem: InventorySystem,
+    doorSystem?: DoorSystem,
+  ) {
+    this.doorSystem = doorSystem;
+  }
+
+  setDoorSystem(doorSystem: DoorSystem) {
+    this.doorSystem = doorSystem;
+    if (this.currentRoomId) {
+      this.doorSystem.setRoom(this.currentRoomId);
+    }
+  }
+
+  load(roomId: RoomId): LoadedRoom {
+    return this.applyRoom(roomId);
+  }
+
+  transitionTo(roomId: RoomId, duration = 320): Promise<LoadedRoom> {
+    return new Promise((resolve) => {
+      const camera = this.scene.cameras.main;
+      const completeLoad = () => {
+        camera.off(Phaser.Cameras.Scene2D.Events.FADE_OUT_COMPLETE, completeLoad);
+        const result = this.applyRoom(roomId);
+        camera.fadeIn(duration, 0, 0, 0);
+        resolve(result);
+      };
+
+      camera.once(Phaser.Cameras.Scene2D.Events.FADE_OUT_COMPLETE, completeLoad);
+      camera.fadeOut(duration, 0, 0, 0);
+    });
+  }
+
+  private applyRoom(roomId: RoomId): LoadedRoom {
+    const config = ROOMS[roomId];
+    if (!config) {
+      throw new Error(`Unknown room id: ${roomId}`);
+    }
+
+    const { width, height } = config.size;
+    this.scene.physics.world.setBounds(0, 0, width, height);
+    this.ensureBackground(config);
+
+    this.inventorySystem.clearGroundItems();
+    this.searchSystem.clearFurniture();
+    this.searchSystem.reset();
+    this.searchSystem.loadFurnitureLayout(config.furniture);
+
+    this.currentRoomId = roomId;
+    this.doorSystem?.setRoom(roomId);
+
+    return {
+      id: config.id,
+      size: { ...config.size },
+      starterItems: [...config.starterItems],
+      restockPoints: config.restockPoints.map((point) => ({ ...point })),
+      spawns: {
+        restock: { ...config.spawns.restock },
+        items: config.spawns.items.map((entry) => ({ ...entry })),
+        monsters: config.spawns.monsters.map((entry) => ({ ...entry })),
+      },
+      keyDrops: config.keyDrops.map((entry) => ({ ...entry })),
+    };
+  }
+
+  private ensureBackground(config: RoomConfig) {
+    const { width, height } = config.size;
+    const centerX = width / 2;
+    const centerY = height / 2;
+    if (!this.background) {
+      this.background = this.scene.add
+        .image(centerX, centerY, config.background.key)
+        .setDepth(-20)
+        .setScrollFactor(0);
+    }
+
+    this.background
+      .setTexture(config.background.key)
+      .setDisplaySize(width, height)
+      .setPosition(centerX, centerY);
+  }
+}

--- a/src/systems/InventorySystem.ts
+++ b/src/systems/InventorySystem.ts
@@ -69,6 +69,10 @@ export class InventorySystem {
     this.createGroundItem(x, y, item.id);
   }
 
+  clearGroundItems() {
+    this.itemsGroup.clear(true, true);
+  }
+
   gainBottle(slot: 0 | 1, x: number, y: number) {
     if (!this.inventory[slot]) {
       this.inventory[slot] = cloneItem('bottle');

--- a/src/systems/SearchSystem.ts
+++ b/src/systems/SearchSystem.ts
@@ -196,6 +196,16 @@ export class SearchSystem {
     layout.forEach(({ x, y, options }) => this.addFurnitureBlock(x, y, options));
   }
 
+  clearFurniture() {
+    this.furnitureGroup.clear(true, true);
+    this.furniture.forEach((entry) => {
+      if (entry.emojiLabel.active) {
+        entry.emojiLabel.destroy();
+      }
+    });
+    this.furniture = [];
+  }
+
   handlePlayerFurnitureCollision = (
     playerObj: Phaser.GameObjects.GameObject,
     furnitureObj: Phaser.GameObjects.GameObject,


### PR DESCRIPTION
## Summary
- add a RoomLoader to centralize room backgrounds, furniture, doors, and spawn configuration
- refactor PlayScene to transition rooms through the loader, use verb-based item actions, and apply mini-elite monster variants
- update supporting systems to reset furniture/items and ensure spawn pacing uses the per-room spawn settings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd71ce5b148332948a01ad9b09f668