### PR TITLE
Add HUD key badges with icons and metadata updates

### DIFF
--- a/src/game/keys.ts
+++ b/src/game/keys.ts
@@ -12,25 +12,25 @@ const KEY_METADATA: Record<KeyId, KeyMetadata> = {
   nurse_badge: {
     id: 'nurse_badge',
     label: 'Nurse Badge',
-    shortLabel: 'NB',
+    shortLabel: 'Med',
     color: 0x7dd6ff,
   },
   admin_badge: {
     id: 'admin_badge',
     label: 'Admin Badge',
-    shortLabel: 'AB',
+    shortLabel: 'Admin',
     color: 0xffcf73,
   },
   pantry_key: {
     id: 'pantry_key',
     label: 'Pantry Key',
-    shortLabel: 'PK',
+    shortLabel: 'Hall',
     color: 0xe88f52,
   },
   front_door_key: {
     id: 'front_door_key',
     label: 'Front Door Key',
-    shortLabel: 'FD',
+    shortLabel: 'Exit',
     color: 0xa0e076,
   },
 };


### PR DESCRIPTION
## Summary
- add a dedicated key badge row to the HUD that renders icons and labels beneath the inventory slots
- hook the badge row into the key storage watcher so it redraws automatically as keys are granted or consumed
- update key metadata to use the requested short labels for each key

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd786709a0833290dd2ea5b5baeaa0