### PR TITLE
Map monster sprites to configuration

### DIFF
--- a/src/content/monsterSprites.ts
+++ b/src/content/monsterSprites.ts
@@ -1,0 +1,64 @@
+import type { MonsterId } from './monsters';
+
+export type MonsterDirection = 'up' | 'down' | 'left' | 'right';
+
+type MonsterSpriteFrameConfig = {
+  width: number;
+  height: number;
+  margin?: number;
+  spacing?: number;
+};
+
+type MonsterSpriteAnimationConfig = {
+  keyPrefix: string;
+  framesPerDirection: number;
+  directions: Record<MonsterDirection, number>;
+};
+
+type MonsterSpriteCollisionConfig = {
+  visibleTop: number;
+  visibleBottom: number;
+};
+
+type MonsterSpriteFrameRates = {
+  idle?: number;
+  walk?: number;
+};
+
+export type MonsterSpriteDefinition = {
+  textureKey: string;
+  texturePath: string;
+  frame: MonsterSpriteFrameConfig;
+  animations: MonsterSpriteAnimationConfig;
+  collision: MonsterSpriteCollisionConfig;
+  frameRates?: MonsterSpriteFrameRates;
+};
+
+export const MONSTER_SPRITES: Record<MonsterId, MonsterSpriteDefinition> = {
+  brine_walker: {
+    textureKey: 'monster',
+    texturePath: 'assets/sprites/monster.png',
+    frame: {
+      width: 184,
+      height: 275,
+    },
+    animations: {
+      keyPrefix: 'monster',
+      framesPerDirection: 4,
+      directions: {
+        down: 0,
+        right: 1,
+        left: 2,
+        up: 3,
+      },
+    },
+    collision: {
+      visibleTop: 38,
+      visibleBottom: 22,
+    },
+    frameRates: {
+      idle: 1,
+      walk: 7,
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- add a shared monster sprite configuration map that records texture, animation, and collision metadata
- load spritesheets and animations from the shared mapping so sprite rows are explicitly tied to monster ids
- update the monster entity to pull its texture, animation keys, and body sizing from the mapped config

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7a34faa48332b828dfbacb786e1b