### PR TITLE
Refactor room content schema and seed bedroom data

### DIFF
--- a/src/game/world.ts
+++ b/src/game/world.ts
@@ -1,4 +1,4 @@
-export type RoomId = 'hallway' | 'infirmary' | 'office' | 'kitchen' | 'entrance';
+export type RoomId = 'bedroom' | 'hallway' | 'infirmary' | 'office' | 'kitchen' | 'entrance';
 
 export type KeyId = 'nurse_badge' | 'admin_badge' | 'pantry_key' | 'front_door_key';
 
@@ -70,6 +70,17 @@ const REQUIREMENTS = {
 
 export const HOUSE_FLOW: RoomFlow[] = [
   {
+    id: 'bedroom',
+    doors: [
+      {
+        id: 'bedroom_hallway',
+        target: 'hallway',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_hall' },
+        coords: DOOR_COORDS.north,
+      },
+    ],
+  },
+  {
     id: 'hallway',
     doors: [
       {
@@ -84,6 +95,12 @@ export const HOUSE_FLOW: RoomFlow[] = [
         sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_office' },
         coords: DOOR_COORDS.right,
         requirement: REQUIREMENTS.nurseBadge,
+      },
+      {
+        id: 'bedroom_hallway',
+        target: 'bedroom',
+        sprite: { key: DOOR_SPRITE_ATLAS, frame: 'door_bedroom' },
+        coords: DOOR_COORDS.south,
       },
     ],
   },

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -14,10 +14,10 @@ import { SearchSystem, type SpawnEmojiFn } from '../systems/SearchSystem';
 import { TelegraphSystem, type MonsterDamageEvent } from '../systems/TelegraphSystem';
 
 type TelegraphSfxKey = 'whoosh' | 'rise' | 'crack' | 'thud';
-import { pickWeightedValue } from '@content/rooms';
+import { cloneWeightedPool, pickWeightedValue } from '@content/rooms';
 import { RoomLoader, type LoadedRoom } from './RoomLoader';
 
-const DEFAULT_ROOM_ID: RoomId = 'hallway';
+const DEFAULT_ROOM_ID: RoomId = 'bedroom';
 
 export class PlayScene extends Phaser.Scene {
   player!: Phaser.Physics.Arcade.Sprite;
@@ -65,6 +65,7 @@ export class PlayScene extends Phaser.Scene {
   constructor() { super('Play'); }
 
   preload() {
+    this.load.image('bg_bedroom', 'assets/sprites/background.png');
     this.load.image('bg_hallway', 'assets/bg_hallway.png');
     this.load.image('bg_infirmary', 'assets/bg_infirmary.png');
     this.load.image('bg_office', 'assets/bg_office.png');
@@ -200,7 +201,7 @@ export class PlayScene extends Phaser.Scene {
       this,
       this.inventorySystem,
       this.roomState.restockPoints.map((point) => ({ ...point })),
-      this.roomState.spawns.items.map((entry) => ({ ...entry })),
+      cloneWeightedPool(this.roomState.spawns.items),
     );
     this.spawnerSystem.spawnInitialItems([...this.roomState.starterItems]);
     this.spawnerSystem.scheduleRestock(this.roomState.spawns.restock);

--- a/src/scenes/RoomLoader.ts
+++ b/src/scenes/RoomLoader.ts
@@ -1,10 +1,10 @@
 import Phaser from 'phaser';
 
-import { ROOMS, type RoomConfig, type RoomSpawns } from '@content/rooms';
+import { ROOMS, cloneWeightedPool, type RoomConfig, type RoomSpawns } from '@content/rooms';
 import type { ItemId } from '@game/items';
 import { DoorSystem } from '@game/doors';
 import type { Weighted } from '@content/rooms';
-import type { RoomId } from '@game/world';
+import type { KeyId, RoomId } from '@game/world';
 
 import { InventorySystem } from '../systems/InventorySystem';
 import { SearchSystem } from '../systems/SearchSystem';
@@ -15,7 +15,7 @@ export type LoadedRoom = {
   starterItems: ItemId[];
   restockPoints: { x: number; y: number }[];
   spawns: RoomSpawns;
-  keyDrops: Weighted<ItemId>[];
+  keysHere: Weighted<KeyId>[];
 };
 
 export class RoomLoader {
@@ -79,14 +79,14 @@ export class RoomLoader {
     return {
       id: config.id,
       size: { ...config.size },
-      starterItems: [...config.starterItems],
-      restockPoints: config.restockPoints.map((point) => ({ ...point })),
+      starterItems: [...config.itemPool.starters],
+      restockPoints: config.spawns.restockPoints.map((point) => ({ ...point })),
       spawns: {
         restock: { ...config.spawns.restock },
-        items: config.spawns.items.map((entry) => ({ ...entry })),
-        monsters: config.spawns.monsters.map((entry) => ({ ...entry })),
+        items: cloneWeightedPool(config.itemPool.restock),
+        monsters: cloneWeightedPool(config.monsters),
       },
-      keyDrops: config.keyDrops.map((entry) => ({ ...entry })),
+      keysHere: cloneWeightedPool(config.keysHere),
     };
   }
 
@@ -96,13 +96,13 @@ export class RoomLoader {
     const centerY = height / 2;
     if (!this.background) {
       this.background = this.scene.add
-        .image(centerX, centerY, config.background.key)
+        .image(centerX, centerY, config.backgroundKey)
         .setDepth(-20)
         .setScrollFactor(0);
     }
 
     this.background
-      .setTexture(config.background.key)
+      .setTexture(config.backgroundKey)
       .setDisplaySize(width, height)
       .setPosition(centerX, centerY);
   }


### PR DESCRIPTION
## Summary
- convert the shared weighted-pool helper to tuple form and add a cloning utility
- remodel room configs to break out item pools, spawn pacing, monster weights, and key drops while filling in data for bedroom through entrance
- update world/scene loaders to start in the bedroom and respect the new room metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7bc5e9248332ba3e65837520c7b2