### PR TITLE
Align item catalog with updated identifiers

### DIFF
--- a/src/content/rooms.ts
+++ b/src/content/rooms.ts
@@ -55,15 +55,16 @@ const RESTOCK_POINTS = [
   { x: 880, y: 560 },
 ];
 
-const STARTER_ITEMS: ItemId[] = ['knife', 'bottle', 'soda', 'match', 'bandaid', 'yoyo'];
+const STARTER_ITEMS: ItemId[] = ['stapler', 'cooking_oil', 'saline', 'flare', 'tape_roll', 'dust_pillow'];
 
 const RESTOCK_POOL: Weighted<ItemId>[] = [
-  { id: 'knife', weight: 1 },
-  { id: 'bottle', weight: 1 },
-  { id: 'soda', weight: 1 },
-  { id: 'match', weight: 1 },
-  { id: 'bandaid', weight: 1 },
-  { id: 'yoyo', weight: 1 },
+  { id: 'stapler', weight: 1 },
+  { id: 'cooking_oil', weight: 1 },
+  { id: 'saline', weight: 1 },
+  { id: 'flare', weight: 1 },
+  { id: 'tape_roll', weight: 1 },
+  { id: 'dust_pillow', weight: 1 },
+  { id: 'salt', weight: 1 },
 ];
 
 const MONSTER_WEIGHTS: Weighted<MonsterId>[] = [{ id: 'brine_walker', weight: 1 }];

--- a/src/game/items.ts
+++ b/src/game/items.ts
@@ -1,21 +1,17 @@
 export type ItemIcon = { key: string; frame?: number };
 
 export type ItemId =
-  | 'match'
-  | 'knife'
-  | 'soda'
-  | 'bottle'
-  | 'bandaid'
-  | 'yoyo'
-  | 'tacks'
-  | 'flashlight'
-  | 'sterile_wrap'
-  | 'fire_bottle'
-  | 'bladed_yoyo'
-  | 'glass_shiv'
-  | 'smoke_patch'
-  | 'adrenal_patch'
-  | 'fizz_bomb';
+  | 'flare'
+  | 'stapler'
+  | 'saline'
+  | 'cooking_oil'
+  | 'tape_roll'
+  | 'dust_pillow'
+  | 'salt'
+  | 'ledger_spike'
+  | 'ink_smoke'
+  | 'brined_salt'
+  | 'ledger_bomb';
 
 export type ItemDef = {
   id: ItemId;
@@ -43,109 +39,81 @@ export const ITEM_ICON_SOURCES: Record<
 };
 
 export const ITEMS: Record<ItemId, ItemDef> = {
-  match: {
-    id: 'match',
-    label: 'Match',
+  flare: {
+    id: 'flare',
+    label: 'Flare',
     uses: 2,
     verb: 'ignite',
     icon: { key: 'item-matches' },
   },
-  knife: {
-    id: 'knife',
-    label: 'Pocket Knife',
+  stapler: {
+    id: 'stapler',
+    label: 'Stapler',
     uses: 5,
     verb: 'slash',
     icon: { key: 'item-knife' },
   },
-  soda: {
-    id: 'soda',
-    label: 'Soda',
+  saline: {
+    id: 'saline',
+    label: 'Saline',
     uses: 2,
     verb: 'drink',
     icon: { key: 'item-soda' },
   },
-  bottle: {
-    id: 'bottle',
-    label: 'Empty Bottle',
+  cooking_oil: {
+    id: 'cooking_oil',
+    label: 'Cooking Oil',
     uses: 1,
     verb: 'throw',
     icon: { key: 'item-empty-bottle' },
   },
-  bandaid: {
-    id: 'bandaid',
-    label: 'Bandaid',
+  tape_roll: {
+    id: 'tape_roll',
+    label: 'Tape Roll',
     uses: 1,
     verb: 'heal',
     icon: { key: 'item-bandaid' },
   },
-  yoyo: {
-    id: 'yoyo',
-    label: 'Yoyo',
+  dust_pillow: {
+    id: 'dust_pillow',
+    label: 'Dust Pillow',
     uses: 3,
     verb: 'swing',
     icon: { key: 'item-yoyo' },
   },
-  tacks: {
-    id: 'tacks',
-    label: 'Thumb Tacks',
-    uses: 3,
-    verb: 'scatter',
+  salt: {
+    id: 'salt',
+    label: 'Salt',
+    uses: 1,
+    verb: 'detonate',
     icon: { key: 'items', frame: 0 },
   },
-  flashlight: {
-    id: 'flashlight',
-    label: 'Flashlight',
-    uses: 4,
-    verb: 'shine',
-    icon: { key: 'items', frame: 1 },
-  },
-  sterile_wrap: {
-    id: 'sterile_wrap',
-    label: 'Sterile Wrap',
-    uses: 1,
-    verb: 'wrap',
-    icon: { key: 'items', frame: 2 },
-  },
-  fire_bottle: {
-    id: 'fire_bottle',
-    label: 'Fire Bottle',
-    uses: 1,
-    verb: 'hurl',
-    icon: { key: 'item-soda' },
-  },
-  bladed_yoyo: {
-    id: 'bladed_yoyo',
-    label: 'Bladed Yoyo',
-    uses: 3,
-    verb: 'reap',
-    icon: { key: 'item-yoyo' },
-  },
-  glass_shiv: {
-    id: 'glass_shiv',
-    label: 'Glass Shiv',
+  ledger_spike: {
+    id: 'ledger_spike',
+    label: 'Ledger Spike',
     uses: 2,
     verb: 'stab',
-    icon: { key: 'item-knife' },
+    icon: { key: 'items', frame: 1 },
   },
-  smoke_patch: {
-    id: 'smoke_patch',
-    label: 'Smoke Patch',
+  ink_smoke: {
+    id: 'ink_smoke',
+    label: 'Ink Smoke',
     uses: 1,
     verb: 'mask',
-    icon: { key: 'item-bandaid' },
+    icon: { key: 'items', frame: 2 },
   },
-  adrenal_patch: {
-    id: 'adrenal_patch',
-    label: 'Adrenal Patch',
+  brined_salt: {
+    id: 'brined_salt',
+    label: 'Brined Salt',
     uses: 1,
     verb: 'boost',
     icon: { key: 'item-bandaid' },
   },
-  fizz_bomb: {
-    id: 'fizz_bomb',
-    label: 'Fizz Pop Bomb',
+  ledger_bomb: {
+    id: 'ledger_bomb',
+    label: 'Ledger Bomb',
     uses: 1,
-    verb: 'detonate',
+    verb: 'hurl',
     icon: { key: 'item-soda' },
   },
 };

--- a/src/game/recipes.ts
+++ b/src/game/recipes.ts
@@ -3,12 +3,11 @@ import type { ItemId } from './items';
 export type Recipe = { a: ItemId; b: ItemId; out: ItemId };
 
 export const RECIPES: Recipe[] = [
-  { a: 'bandaid', b: 'match', out: 'smoke_patch' },
-  { a: 'bandaid', b: 'soda', out: 'adrenal_patch' },
-  { a: 'bottle', b: 'knife', out: 'glass_shiv' },
-  { a: 'bottle', b: 'match', out: 'fire_bottle' },
-  { a: 'match', b: 'soda', out: 'fizz_bomb' },
-  { a: 'knife', b: 'yoyo', out: 'bladed_yoyo' },
+  { a: 'tape_roll', b: 'flare', out: 'ink_smoke' },
+  { a: 'tape_roll', b: 'saline', out: 'brined_salt' },
+  { a: 'cooking_oil', b: 'stapler', out: 'ledger_spike' },
+  { a: 'cooking_oil', b: 'flare', out: 'ledger_bomb' },
+  { a: 'flare', b: 'saline', out: 'salt' },
 ];
 
 const RECIPE_LOOKUP = RECIPES.reduce<Map<string, ItemId>>((acc, recipe) => {

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -306,7 +306,7 @@ export class PlayScene extends Phaser.Scene {
       case 'drink':
         this.speedBoost(3000);
         this.telegraphSystem.showSelfBuffTelegraph('🥤', 0x9de4ff, 420);
-        this.afterDelay(3000, () => this.gainBottle(slot));
+        this.afterDelay(3000, () => this.gainSalt(slot));
         return true;
       case 'hurl':
         this.throwBottle(3, true);
@@ -410,8 +410,8 @@ export class PlayScene extends Phaser.Scene {
     }
   }
 
-  private gainBottle(slot: 0 | 1) {
-    this.inventorySystem.gainBottle(slot, this.player.x + 8, this.player.y + 8);
+  private gainSalt(slot: 0 | 1) {
+    this.inventorySystem.gainSalt(slot, this.player.x + 8, this.player.y + 8);
   }
 
   damagePlayer(

--- a/src/systems/InventorySystem.ts
+++ b/src/systems/InventorySystem.ts
@@ -73,17 +73,17 @@ export class InventorySystem {
     this.itemsGroup.clear(true, true);
   }
 
-  gainBottle(slot: 0 | 1, x: number, y: number) {
+  gainSalt(slot: 0 | 1, x: number, y: number) {
     if (!this.inventory[slot]) {
-      this.inventory[slot] = cloneItem('bottle');
+      this.inventory[slot] = cloneItem('salt');
       return;
     }
     const other = slot === 0 ? 1 : 0;
     if (!this.inventory[other]) {
-      this.inventory[other] = cloneItem('bottle');
+      this.inventory[other] = cloneItem('salt');
       return;
     }
-    this.createGroundItem(x, y, 'bottle');
+    this.createGroundItem(x, y, 'salt');
   }
 
   craft() {

--- a/src/systems/SearchSystem.ts
+++ b/src/systems/SearchSystem.ts
@@ -174,7 +174,7 @@ export class SearchSystem {
         rect,
         searchDuration: options.searchDuration ?? 2400,
         checkPoints: options.checkPoints ?? [0.5],
-        lootTable: options.lootTable ?? ['bandaid', 'bottle', 'match'],
+        lootTable: options.lootTable ?? ['tape_roll', 'cooking_oil', 'flare'],
         findChance: options.findChance ?? 0.4,
         emoji: options.emoji ?? this.getFurnitureEmoji(options.name ?? ''),
         emojiLabel: this.scene.add


### PR DESCRIPTION
## Summary
- replace the item ID union and definitions with the new catalog of base and crafted gear, including updated icons, verbs, and uses
- update crafting recipes, starter/restock pools, search loot defaults, and saline leftovers to reference the renamed items

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7b9d6a8483328788d7cb50b46266