### PR TITLE
Fix atlas loading for furniture and doors textures

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -88,8 +88,8 @@ export class PlayScene extends Phaser.Scene {
       });
     });
 
-    this.load.atlasJSONHash('furniture', 'assets/furniture_sheet.png', 'assets/furniture_atlas.json');
-    this.load.atlasJSONHash('doors_windows', 'assets/doors_windows_sheet.png', 'assets/doors_windows_atlas.json');
+    this.load.atlas('furniture', 'assets/furniture_sheet.png', 'assets/furniture_atlas.json');
+    this.load.atlas('doors_windows', 'assets/doors_windows_sheet.png', 'assets/doors_windows_atlas.json');
 
     Object.entries(ITEM_ICON_SOURCES).forEach(([key, source]) => {
       if (source.type === 'sheet') {


### PR DESCRIPTION
## Summary
- replace deprecated atlasJSONHash calls with the standard load.atlas loader in `PlayScene`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7f91bc5883328d0477698210d86f