### PR TITLE
Fix room loading by clearing search furniture

### DIFF
--- a/src/systems/SearchSystem.ts
+++ b/src/systems/SearchSystem.ts
@@ -100,6 +100,24 @@ export class SearchSystem {
     this.searchBar.setVisible(false);
   }
 
+  clearFurniture() {
+    for (const furniture of this.furniture) {
+      furniture.emojiLabel.destroy();
+    }
+
+    this.furnitureGroup.children.each((child) => {
+      const rect = child as Phaser.GameObjects.Rectangle;
+      const sprite = rect.getData('spriteRef') as Phaser.GameObjects.Image | null;
+      if (sprite) {
+        sprite.destroy();
+      }
+      rect.setData('spriteRef', null);
+    });
+
+    this.furnitureGroup.clear(true, true);
+    this.furniture = [];
+  }
+
   isSearching() {
     return this.searching;
   }


### PR DESCRIPTION
## Summary
- add a SearchSystem.clearFurniture helper that removes leftover sprites and labels when changing rooms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd85f17194833297b0d00b2d9861e3