### PR TITLE
Fix monster collision body scaling

### DIFF
--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -154,8 +154,8 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
     const visibleTop = this.spriteConfig.collision.visibleTop;
     const visibleBottom = this.spriteConfig.collision.visibleBottom;
     const visibleHeight = frameHeight - visibleTop - visibleBottom;
-    body.setSize(frameWidth / monsterScaleX, visibleHeight / monsterScaleY);
-    body.setOffset(0, visibleTop / monsterScaleY);
+    body.setSize(frameWidth * monsterScaleX, visibleHeight * monsterScaleY);
+    body.setOffset(0, visibleTop * monsterScaleY);
   }
 
   private setFacingFromVector(dx: number, dy: number) {


### PR DESCRIPTION
## Summary
- scale the monster physics body size and offset with the sprite's actual scale
- keep the collision body aligned with the visible portion of the sprite

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd90958aa0833294879b8ff66c7286