### PR TITLE
Enable hurtbox debug overlay and tune brine walker hurtbox

### DIFF
--- a/src/combat/hurtbox.ts
+++ b/src/combat/hurtbox.ts
@@ -7,8 +7,8 @@ export type HurtSpec = {
 
 export const HURTBOX_SPECS: Record<string, HurtSpec> = {
   brine_walker: {
-    core: { halfLen: 96, radius: 58, footOffsetY: 14 },
-    head: { offset: 110, radius: 42 },
+    core: { halfLen: 68, radius: 38, footOffsetY: 14 },
+    head: { offset: 76, radius: 28 },
     tail: { offset: 42, radius: 30 },
     dashShrink: 0.85,
   },


### PR DESCRIPTION
## Summary
- enable a development-only hurtbox debug overlay that visualizes the monster hurtbox shapes
- cache the current hurtbox geometry for reuse and cleanup debug graphics when the monster is destroyed
- tighten the brine walker core and head hurtbox measurements to fit inside the sprite silhouette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddb592794483328215a0f08aca8627