### PR TITLE
Add combat geometry helpers and Brine Walker rig

### DIFF
--- a/src/combat/hitbox.ts
+++ b/src/combat/hitbox.ts
@@ -1,0 +1,93 @@
+export type CommitWindow = {
+  windupMs: number;
+  activeMs: number;
+  recoverMs: number;
+};
+
+export type HitboxPhase = 'idle' | 'windup' | 'active' | 'recover' | 'done';
+
+export class HitboxTimeline {
+  private elapsed = 0;
+  private running = false;
+  private looping = false;
+  private totalDuration = 0;
+
+  constructor(private readonly window: CommitWindow) {
+    this.totalDuration = window.windupMs + window.activeMs + window.recoverMs;
+  }
+
+  start(loop = false) {
+    this.elapsed = 0;
+    this.running = true;
+    this.looping = loop;
+  }
+
+  stop() {
+    this.running = false;
+    this.elapsed = 0;
+  }
+
+  advance(deltaMs: number) {
+    if (!this.running) {
+      return;
+    }
+    this.elapsed += deltaMs;
+    if (this.looping) {
+      this.elapsed = this.elapsed % this.totalDuration;
+    } else if (this.elapsed >= this.totalDuration) {
+      this.elapsed = this.totalDuration;
+      this.running = false;
+    }
+  }
+
+  get phase(): HitboxPhase {
+    return phaseAtTime(this.window, this.elapsed, this.running);
+  }
+
+  get isActive() {
+    const { windupMs, activeMs } = this.window;
+    return this.elapsed >= windupMs && this.elapsed < windupMs + activeMs;
+  }
+
+  get time() {
+    return this.elapsed;
+  }
+
+  get duration() {
+    return this.totalDuration;
+  }
+}
+
+export function phaseAtTime(window: CommitWindow, elapsed: number, running = true): HitboxPhase {
+  const { windupMs, activeMs, recoverMs } = window;
+  const total = windupMs + activeMs + recoverMs;
+  if (!running && elapsed >= total) {
+    return 'done';
+  }
+  if (elapsed < 0) {
+    return 'idle';
+  }
+  if (elapsed < windupMs) {
+    return 'windup';
+  }
+  if (elapsed < windupMs + activeMs) {
+    return 'active';
+  }
+  if (elapsed < total) {
+    return 'recover';
+  }
+  return running ? 'recover' : 'done';
+}
+
+export function clampToActive(window: CommitWindow, elapsed: number) {
+  const { windupMs, activeMs } = window;
+  const start = windupMs;
+  const end = windupMs + activeMs;
+  if (elapsed <= start) {
+    return start;
+  }
+  if (elapsed >= end) {
+    return end;
+  }
+  return elapsed;
+}

--- a/src/combat/hurtbox_rig.ts
+++ b/src/combat/hurtbox_rig.ts
@@ -1,0 +1,83 @@
+import { cloneShape, lerpShape, type HurtShape } from './shapes';
+
+export type HurtboxRigKeyframe = {
+  time: number;
+  shapes: HurtShape[];
+};
+
+export type HurtboxRigTrack = {
+  loop: boolean;
+  frames: HurtboxRigKeyframe[];
+};
+
+export type HurtboxRig = Record<string, HurtboxRigTrack>;
+
+function normalizeTime(track: HurtboxRigTrack, time: number) {
+  if (track.frames.length === 0) {
+    return 0;
+  }
+  const duration = track.frames[track.frames.length - 1].time;
+  if (duration <= 0) {
+    return 0;
+  }
+  if (!track.loop) {
+    return Math.max(0, Math.min(time, duration));
+  }
+  const wrapped = time % duration;
+  return wrapped < 0 ? wrapped + duration : wrapped;
+}
+
+function interpolateShapes(prev: HurtShape[], next: HurtShape[], t: number) {
+  const count = Math.min(prev.length, next.length);
+  const result: HurtShape[] = [];
+  for (let i = 0; i < count; i += 1) {
+    result.push(lerpShape(prev[i], next[i], t));
+  }
+  if (prev.length > count) {
+    for (let i = count; i < prev.length; i += 1) {
+      result.push(cloneShape(prev[i]));
+    }
+  } else if (next.length > count) {
+    for (let i = count; i < next.length; i += 1) {
+      result.push(cloneShape(next[i]));
+    }
+  }
+  return result;
+}
+
+export function sampleHurtboxRig(
+  rig: HurtboxRig,
+  state: string,
+  time: number
+): HurtShape[] {
+  const track = rig[state];
+  if (!track || track.frames.length === 0) {
+    return [];
+  }
+
+  if (track.frames.length === 1) {
+    return track.frames[0].shapes.map((shape) => cloneShape(shape));
+  }
+
+  const normalizedTime = normalizeTime(track, time);
+
+  let prev = track.frames[0];
+  for (let i = 1; i < track.frames.length; i += 1) {
+    const frame = track.frames[i];
+    if (normalizedTime < frame.time) {
+      const span = frame.time - prev.time;
+      const t = span <= 0 ? 0 : (normalizedTime - prev.time) / span;
+      return interpolateShapes(prev.shapes, frame.shapes, t);
+    }
+    prev = frame;
+  }
+
+  const last = track.frames[track.frames.length - 1];
+  if (track.loop) {
+    const first = track.frames[0];
+    const span = last.time;
+    const t = span <= 0 ? 0 : (normalizedTime - last.time) / (span === 0 ? 1 : span);
+    return interpolateShapes(last.shapes, first.shapes, t);
+  }
+  return last.shapes.map((shape) => cloneShape(shape));
+}

--- a/src/combat/overlap.ts
+++ b/src/combat/overlap.ts
@@ -1,0 +1,152 @@
+import Phaser from 'phaser';
+import type { Capsule, Circle, HurtShape, Vec2 } from './shapes';
+
+const EPS = 1e-6;
+
+function vec(x: number, y: number): Vec2 {
+  return { x, y };
+}
+
+function sub(a: Vec2, b: Vec2): Vec2 {
+  return vec(a.x - b.x, a.y - b.y);
+}
+
+function add(a: Vec2, b: Vec2): Vec2 {
+  return vec(a.x + b.x, a.y + b.y);
+}
+
+function scale(v: Vec2, s: number): Vec2 {
+  return vec(v.x * s, v.y * s);
+}
+
+function dot(a: Vec2, b: Vec2) {
+  return a.x * b.x + a.y * b.y;
+}
+
+function lenSq(v: Vec2) {
+  return dot(v, v);
+}
+
+function clamp01(t: number) {
+  return Phaser.Math.Clamp(t, 0, 1);
+}
+
+function distancePointSegmentSq(point: Vec2, a: Vec2, b: Vec2) {
+  const ab = sub(b, a);
+  const ap = sub(point, a);
+  const denom = lenSq(ab);
+  if (denom < EPS) {
+    return lenSq(ap);
+  }
+  const t = clamp01(dot(ap, ab) / denom);
+  const closest = add(a, scale(ab, t));
+  return lenSq(sub(point, closest));
+}
+
+function segmentSegmentDistanceSq(a0: Vec2, a1: Vec2, b0: Vec2, b1: Vec2) {
+  const u = sub(a1, a0);
+  const v = sub(b1, b0);
+  const w = sub(a0, b0);
+  const a = dot(u, u);
+  const b = dot(u, v);
+  const c = dot(v, v);
+  const d = dot(u, w);
+  const e = dot(v, w);
+  const denom = a * c - b * b;
+
+  let s: number;
+  let t: number;
+
+  if (a < EPS && c < EPS) {
+    return lenSq(w);
+  }
+
+  if (a < EPS) {
+    s = 0;
+    t = clamp01(e / c);
+  } else if (c < EPS) {
+    t = 0;
+    s = clamp01(-d / a);
+  } else if (denom < EPS) {
+    s = 0;
+    t = clamp01(e / c);
+  } else {
+    s = clamp01((b * e - c * d) / denom);
+    t = (b * s + e) / c;
+    if (t < 0) {
+      t = 0;
+      s = clamp01(-d / a);
+    } else if (t > 1) {
+      t = 1;
+      s = clamp01((b - d) / a);
+    }
+  }
+
+  const pA = add(a0, scale(u, s));
+  const pB = add(b0, scale(v, t));
+  return lenSq(sub(pA, pB));
+}
+
+function capsuleCapsuleDistSq(a: Capsule, b: Capsule) {
+  const a0 = vec(a.ax, a.ay);
+  const a1 = vec(a.bx, a.by);
+  const b0 = vec(b.ax, b.ay);
+  const b1 = vec(b.bx, b.by);
+  return segmentSegmentDistanceSq(a0, a1, b0, b1);
+}
+
+function circleCircleOverlap(a: Circle, b: Circle) {
+  const distSq = (a.x - b.x) ** 2 + (a.y - b.y) ** 2;
+  const r = a.r + b.r;
+  return distSq <= r * r + EPS;
+}
+
+function circleCapsuleOverlap(circle: Circle, capsule: Capsule) {
+  const pt = vec(circle.x, circle.y);
+  const a = vec(capsule.ax, capsule.ay);
+  const b = vec(capsule.bx, capsule.by);
+  const distSq = distancePointSegmentSq(pt, a, b);
+  const rad = circle.r + capsule.r;
+  return distSq <= rad * rad + EPS;
+}
+
+function capsuleCapsuleOverlap(a: Capsule, b: Capsule) {
+  const distSq = capsuleCapsuleDistSq(a, b);
+  const rad = a.r + b.r;
+  return distSq <= rad * rad + EPS;
+}
+
+export function shapesOverlap(a: HurtShape, b: HurtShape) {
+  if (a.kind === 'circle' && b.kind === 'circle') {
+    return circleCircleOverlap(a, b);
+  }
+  if (a.kind === 'circle' && b.kind === 'capsule') {
+    return circleCapsuleOverlap(a, b);
+  }
+  if (a.kind === 'capsule' && b.kind === 'circle') {
+    return circleCapsuleOverlap(b, a);
+  }
+  return capsuleCapsuleOverlap(a as Capsule, b as Capsule);
+}
+
+export function distanceToShape(point: Vec2, shape: HurtShape) {
+  if (shape.kind === 'circle') {
+    const dist = Math.sqrt((point.x - shape.x) ** 2 + (point.y - shape.y) ** 2);
+    return Math.max(0, dist - shape.r);
+  }
+  const a = vec(shape.ax, shape.ay);
+  const b = vec(shape.bx, shape.by);
+  const distSq = distancePointSegmentSq(point, a, b);
+  return Math.max(0, Math.sqrt(distSq) - shape.r);
+}
+
+export function shapesIntersect(shapesA: HurtShape[], shapesB: HurtShape[]) {
+  for (const a of shapesA) {
+    for (const b of shapesB) {
+      if (shapesOverlap(a, b)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/src/combat/shapes.ts
+++ b/src/combat/shapes.ts
@@ -1,12 +1,8 @@
 import Phaser from 'phaser';
 
-export type Capsule = {
-  kind: 'capsule';
-  ax: number;
-  ay: number;
-  bx: number;
-  by: number;
-  r: number;
+export type Vec2 = {
+  x: number;
+  y: number;
 };
 
 export type Circle = {
@@ -16,7 +12,30 @@ export type Circle = {
   r: number;
 };
 
-export type HurtShape = Capsule | Circle;
+export type Capsule = {
+  kind: 'capsule';
+  ax: number;
+  ay: number;
+  bx: number;
+  by: number;
+  r: number;
+};
+
+export type HurtShape = Circle | Capsule;
+
+export type HurtboxPart = 'core' | 'head' | 'tail' | 'extra';
+
+export type Hurtbox = {
+  part: HurtboxPart;
+  shape: HurtShape;
+};
+
+export type TeamId = 'player' | 'monster' | 'neutral';
+
+export type Team = {
+  id: TeamId;
+  hostileTo: TeamId[];
+};
 
 export function getShapeBounds(shape: HurtShape) {
   if (shape.kind === 'circle') {
@@ -28,4 +47,36 @@ export function getShapeBounds(shape: HurtShape) {
   const maxX = Math.max(shape.ax, shape.bx) + shape.r;
   const maxY = Math.max(shape.ay, shape.by) + shape.r;
   return new Phaser.Geom.Rectangle(minX, minY, maxX - minX, maxY - minY);
+}
+
+export function cloneShape(shape: HurtShape): HurtShape {
+  if (shape.kind === 'circle') {
+    const { x, y, r } = shape;
+    return { kind: 'circle', x, y, r };
+  }
+  const { ax, ay, bx, by, r } = shape;
+  return { kind: 'capsule', ax, ay, bx, by, r };
+}
+
+export function lerpShape(a: HurtShape, b: HurtShape, t: number): HurtShape {
+  const lt = Phaser.Math.Clamp(t, 0, 1);
+  if (a.kind === 'circle' && b.kind === 'circle') {
+    return {
+      kind: 'circle',
+      x: Phaser.Math.Linear(a.x, b.x, lt),
+      y: Phaser.Math.Linear(a.y, b.y, lt),
+      r: Phaser.Math.Linear(a.r, b.r, lt),
+    };
+  }
+  if (a.kind === 'capsule' && b.kind === 'capsule') {
+    return {
+      kind: 'capsule',
+      ax: Phaser.Math.Linear(a.ax, b.ax, lt),
+      ay: Phaser.Math.Linear(a.ay, b.ay, lt),
+      bx: Phaser.Math.Linear(a.bx, b.bx, lt),
+      by: Phaser.Math.Linear(a.by, b.by, lt),
+      r: Phaser.Math.Linear(a.r, b.r, lt),
+    };
+  }
+  return cloneShape(lt < 0.5 ? a : b);
 }

--- a/src/content/collision/brine_walker.ts
+++ b/src/content/collision/brine_walker.ts
@@ -1,0 +1,146 @@
+import type { HurtboxRig } from '../../combat/hurtbox_rig';
+
+export const BRINE_WALKER_HURTBOX_RIG: HurtboxRig = {
+  idle: {
+    loop: true,
+    frames: [
+      {
+        time: 0,
+        shapes: [
+          { kind: 'capsule', ax: -90, ay: 10, bx: 90, by: 10, r: 58 },
+          { kind: 'circle', x: 110, y: 6, r: 40 },
+          { kind: 'circle', x: -60, y: 4, r: 30 },
+        ],
+      },
+      {
+        time: 400,
+        shapes: [
+          { kind: 'capsule', ax: -92, ay: 8, bx: 94, by: 12, r: 58 },
+          { kind: 'circle', x: 114, y: 8, r: 40 },
+          { kind: 'circle', x: -62, y: 2, r: 30 },
+        ],
+      },
+      {
+        time: 800,
+        shapes: [
+          { kind: 'capsule', ax: -90, ay: 10, bx: 90, by: 10, r: 58 },
+          { kind: 'circle', x: 110, y: 6, r: 40 },
+          { kind: 'circle', x: -60, y: 4, r: 30 },
+        ],
+      },
+    ],
+  },
+  chase: {
+    loop: true,
+    frames: [
+      {
+        time: 0,
+        shapes: [
+          { kind: 'capsule', ax: -95, ay: 6, bx: 104, by: 18, r: 54 },
+          { kind: 'circle', x: 124, y: 20, r: 38 },
+          { kind: 'circle', x: -70, y: -2, r: 28 },
+        ],
+      },
+      {
+        time: 350,
+        shapes: [
+          { kind: 'capsule', ax: -90, ay: 4, bx: 110, by: 20, r: 54 },
+          { kind: 'circle', x: 128, y: 22, r: 38 },
+          { kind: 'circle', x: -72, y: -6, r: 28 },
+        ],
+      },
+      {
+        time: 700,
+        shapes: [
+          { kind: 'capsule', ax: -95, ay: 6, bx: 104, by: 18, r: 54 },
+          { kind: 'circle', x: 124, y: 20, r: 38 },
+          { kind: 'circle', x: -70, y: -2, r: 28 },
+        ],
+      },
+    ],
+  },
+  windup: {
+    loop: false,
+    frames: [
+      {
+        time: 0,
+        shapes: [
+          { kind: 'capsule', ax: -86, ay: 14, bx: 102, by: 32, r: 56 },
+          { kind: 'circle', x: 136, y: 36, r: 42 },
+          { kind: 'circle', x: -56, y: 0, r: 26 },
+        ],
+      },
+      {
+        time: 300,
+        shapes: [
+          { kind: 'capsule', ax: -80, ay: 20, bx: 112, by: 40, r: 54 },
+          { kind: 'circle', x: 150, y: 44, r: 42 },
+          { kind: 'circle', x: -52, y: -6, r: 24 },
+        ],
+      },
+    ],
+  },
+  commit: {
+    loop: false,
+    frames: [
+      {
+        time: 0,
+        shapes: [
+          { kind: 'capsule', ax: -60, ay: 18, bx: 160, by: 36, r: 52 },
+          { kind: 'circle', x: 190, y: 40, r: 38 },
+          { kind: 'circle', x: -30, y: -8, r: 22 },
+        ],
+      },
+      {
+        time: 220,
+        shapes: [
+          { kind: 'capsule', ax: -54, ay: 16, bx: 170, by: 34, r: 50 },
+          { kind: 'circle', x: 200, y: 38, r: 36 },
+          { kind: 'circle', x: -28, y: -10, r: 22 },
+        ],
+      },
+    ],
+  },
+  recover: {
+    loop: false,
+    frames: [
+      {
+        time: 0,
+        shapes: [
+          { kind: 'capsule', ax: -92, ay: 10, bx: 110, by: 22, r: 56 },
+          { kind: 'circle', x: 132, y: 24, r: 38 },
+          { kind: 'circle', x: -68, y: -4, r: 28 },
+        ],
+      },
+      {
+        time: 320,
+        shapes: [
+          { kind: 'capsule', ax: -98, ay: 8, bx: 104, by: 18, r: 56 },
+          { kind: 'circle', x: 126, y: 22, r: 38 },
+          { kind: 'circle', x: -72, y: -6, r: 28 },
+        ],
+      },
+    ],
+  },
+  dash: {
+    loop: false,
+    frames: [
+      {
+        time: 0,
+        shapes: [
+          { kind: 'capsule', ax: -72, ay: -6, bx: 128, by: 18, r: 48 },
+          { kind: 'circle', x: 150, y: 20, r: 34 },
+          { kind: 'circle', x: -40, y: -22, r: 22 },
+        ],
+      },
+      {
+        time: 200,
+        shapes: [
+          { kind: 'capsule', ax: -70, ay: -8, bx: 132, by: 16, r: 48 },
+          { kind: 'circle', x: 152, y: 18, r: 34 },
+          { kind: 'circle', x: -44, y: -24, r: 22 },
+        ],
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- extend combat shape definitions with team and hurtbox helpers
- add analytic overlap, hitbox timeline, and hurtbox rig sampling utilities
- add Brine Walker collision rig data for state-driven hurtboxes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddc9560fd8833292dd6c3d77672b68