### PR TITLE
Refactor monster content schema

### DIFF
--- a/src/content/monsters.ts
+++ b/src/content/monsters.ts
@@ -1,69 +1,142 @@
 export type MonsterId = 'brine_walker';
 
-export type MoveId = 'sweep' | 'smash' | 'rush' | 'roar';
+export type MonsterMoveId = 'sweep' | 'smash' | 'rush' | 'roar';
 
-export type Move = {
-  id: MoveId;
+export type MonsterMovePhase = 'preWarn' | 'windUp' | 'commit' | 'recovery';
+
+export type MonsterMoveShape =
+  | {
+      type: 'arc';
+      radius: number;
+      spread: number;
+      origin: 'self' | 'target';
+      track?: boolean;
+      phases: MonsterMovePhase[];
+    }
+  | {
+      type: 'circle';
+      radius: number;
+      origin: 'self' | 'target';
+      track?: boolean;
+      phases: MonsterMovePhase[];
+    }
+  | {
+      type: 'lane';
+      length: number;
+      halfWidth: number;
+      origin: 'self';
+      track?: boolean;
+      phases: MonsterMovePhase[];
+    }
+  | {
+      type: 'ring';
+      innerRadius: number;
+      outerRadius: number;
+      origin: 'self';
+      phases: MonsterMovePhase[];
+    };
+
+export type MonsterMove = {
+  id: MonsterMoveId;
+  label: string;
   cooldown: number;
-  timings: {
-    preWarn: number;
-    windUp: number;
-    commit: number;
-    recovery: number;
-  };
+  timings: Record<MonsterMovePhase, number>;
+  shapes: MonsterMoveShape[];
 };
 
 export type MonsterDefinition = {
-  id: MonsterId;
-  name: string;
-  baseTint: number;
-  stats: {
-    hp: number;
-    speed: number;
-  };
-  rage: {
-    threshold: number;
-    speedMultiplier: number;
-  };
-  moveOrder: MoveId[];
-  moves: Record<MoveId, Move>;
+  label: string;
+  hp: number;
+  moves: MonsterMove[];
 };
 
 export const MONSTERS: Record<MonsterId, MonsterDefinition> = {
   brine_walker: {
-    id: 'brine_walker',
-    name: 'Brine Walker',
-    baseTint: 0xffffff,
-    stats: {
-      hp: 12,
-      speed: 140,
-    },
-    rage: {
-      threshold: 0.4,
-      speedMultiplier: 1.4,
-    },
-    moveOrder: ['sweep', 'smash', 'rush', 'roar'],
-    moves: {
-      sweep: {
+    label: 'Brine Walker',
+    hp: 12,
+    moves: [
+      {
         id: 'sweep',
+        label: 'Tidal Sweep',
         cooldown: 2.5,
-        timings: { preWarn: 250, windUp: 350, commit: 200, recovery: 400 },
+        timings: {
+          preWarn: 250,
+          windUp: 350,
+          commit: 200,
+          recovery: 400,
+        },
+        shapes: [
+          {
+            type: 'arc',
+            radius: 140,
+            spread: 120,
+            origin: 'self',
+            track: true,
+            phases: ['preWarn', 'windUp', 'commit'],
+          },
+        ],
       },
-      smash: {
+      {
         id: 'smash',
+        label: 'Anchor Smash',
         cooldown: 4,
-        timings: { preWarn: 300, windUp: 450, commit: 180, recovery: 450 },
+        timings: {
+          preWarn: 300,
+          windUp: 450,
+          commit: 180,
+          recovery: 450,
+        },
+        shapes: [
+          {
+            type: 'circle',
+            radius: 100,
+            origin: 'target',
+            track: true,
+            phases: ['preWarn', 'windUp', 'commit'],
+          },
+        ],
       },
-      rush: {
+      {
         id: 'rush',
+        label: 'Undertow Rush',
         cooldown: 5,
-        timings: { preWarn: 300, windUp: 400, commit: 300, recovery: 500 },
+        timings: {
+          preWarn: 300,
+          windUp: 400,
+          commit: 300,
+          recovery: 500,
+        },
+        shapes: [
+          {
+            type: 'lane',
+            length: 420,
+            halfWidth: 32,
+            origin: 'self',
+            track: true,
+            phases: ['preWarn', 'windUp', 'commit'],
+          },
+        ],
       },
-      roar: {
+      {
         id: 'roar',
+        label: 'Brine Roar',
         cooldown: 7,
-        timings: { preWarn: 250, windUp: 350, commit: 150, recovery: 350 },
+        timings: {
+          preWarn: 250,
+          windUp: 350,
+          commit: 150,
+          recovery: 350,
+        },
+        shapes: [
+          {
+            type: 'ring',
+            innerRadius: 0,
+            outerRadius: 250,
+            origin: 'self',
+            phases: ['preWarn', 'windUp', 'commit'],
+          },
+        ],
       },
-    },
+    ],
   },
 };

--- a/src/content/monstersLegacy.ts
+++ b/src/content/monstersLegacy.ts
@@ -1,0 +1,80 @@
+import { MONSTERS, type MonsterDefinition as ContentMonsterDefinition, type MonsterId, type MonsterMove } from './monsters';
+
+export type MoveId = MonsterMove['id'];
+
+export type Move = {
+  id: MoveId;
+  cooldown: number;
+  timings: MonsterMove['timings'];
+};
+
+export type LegacyMonsterDefinition = {
+  id: MonsterId;
+  name: string;
+  baseTint: number;
+  stats: {
+    hp: number;
+    speed: number;
+  };
+  rage: {
+    threshold: number;
+    speedMultiplier: number;
+  };
+  moveOrder: MoveId[];
+  moves: Record<MoveId, Move>;
+};
+
+const FALLBACK_STATS: Record<MonsterId, {
+  baseTint: number;
+  speed: number;
+  rageThreshold: number;
+  rageSpeedMultiplier: number;
+}> = {
+  brine_walker: {
+    baseTint: 0xffffff,
+    speed: 140,
+    rageThreshold: 0.4,
+    rageSpeedMultiplier: 1.4,
+  },
+};
+
+const toLegacyDefinition = (
+  id: MonsterId,
+  content: ContentMonsterDefinition,
+): LegacyMonsterDefinition => {
+  const defaults = FALLBACK_STATS[id];
+  const moveOrder = content.moves.map((move) => move.id);
+  const moves = content.moves.reduce<Record<MoveId, Move>>((acc, move) => {
+    acc[move.id] = {
+      id: move.id,
+      cooldown: move.cooldown,
+      timings: move.timings,
+    };
+    return acc;
+  }, {} as Record<MoveId, Move>);
+
+  return {
+    id,
+    name: content.label,
+    baseTint: defaults?.baseTint ?? 0xffffff,
+    stats: {
+      hp: content.hp,
+      speed: defaults?.speed ?? 120,
+    },
+    rage: {
+      threshold: defaults?.rageThreshold ?? 0.5,
+      speedMultiplier: defaults?.rageSpeedMultiplier ?? 1.2,
+    },
+    moveOrder,
+    moves,
+  };
+};
+
+export const LEGACY_MONSTERS: Record<MonsterId, LegacyMonsterDefinition> = Object.fromEntries(
+  Object.entries(MONSTERS).map(([id, definition]) => [
+    id as MonsterId,
+    toLegacyDefinition(id as MonsterId, definition),
+  ]),
+) as Record<MonsterId, LegacyMonsterDefinition>;
+
+export type { MonsterId } from './monsters';

--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -1,6 +1,12 @@
 import Phaser from 'phaser';
 import { MONSTER_SPRITES, type MonsterSpriteDefinition } from '@content/monsterSprites';
-import { MONSTERS, type MonsterDefinition, type MonsterId, type Move, type MoveId } from '@content/monsters';
+import {
+  LEGACY_MONSTERS as MONSTERS,
+  type LegacyMonsterDefinition as MonsterDefinition,
+  type MonsterId,
+  type Move,
+  type MoveId,
+} from '@content/monstersLegacy';
 import { MonsterHurtbox, type MonsterPose, type MonsterStateTag, type HurtboxShapeInstance } from '../combat/monsterHurtbox';
 import { getShapeBounds } from '../combat/shapes';
 const TELEGRAPH_COLORS = {


### PR DESCRIPTION
## Summary
- replace the monster content file with the new label/hp/move schema that includes telegraph shape metadata
- add a legacy compatibility adapter that maps the new schema back to the runtime structure used by the monster class
- update the monster implementation to pull its configuration from the compatibility adapter

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddcb6839ac8332a997c1ed4e4fcd65