### PR TITLE
Use rig-sampled hurtboxes for Brine Walker

### DIFF
--- a/src/game/monster.ts
+++ b/src/game/monster.ts
@@ -123,6 +123,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
   private burningUntil = 0;
   private hurtbox: MonsterHurtbox;
   private hurtState: MonsterStateTag = 'idle';
+  private hurtStateElapsed = 0;
   private lastPose: MonsterPose;
   private hitboxDefs: MonsterHitboxDefinition[] = [
     { id: 'core', part: 'core', damageMultiplier: 1 },
@@ -215,6 +216,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
       return;
     }
     this.hurtState = state;
+    this.hurtStateElapsed = 0;
     this.updateHurtbox(state);
   }
 
@@ -383,6 +385,25 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
         damageMultiplier,
       };
     });
+  }
+
+  protected getCurrentPose(): MonsterPose {
+    if (!this.lastPose) {
+      this.lastPose = this.buildPose();
+    }
+    return this.lastPose;
+  }
+
+  protected getCurrentHurtState(): MonsterStateTag {
+    return this.hurtState;
+  }
+
+  protected getHurtStateElapsed(): number {
+    return this.hurtStateElapsed;
+  }
+
+  protected getHitboxDefinitions(): MonsterHitboxDefinition[] {
+    return this.hitboxDefs;
   }
 
   resolveTelegraphHit(id: string) {
@@ -1097,6 +1118,7 @@ export class Monster extends Phaser.Physics.Arcade.Sprite {
   }
 
   update(dt: number, player: Phaser.Physics.Arcade.Sprite) {
+    this.hurtStateElapsed += dt;
     this.layoutHpBar();
     this.updateRageState();
     this.updateHurtbox();

--- a/src/monsters/brine_walker.ts
+++ b/src/monsters/brine_walker.ts
@@ -1,7 +1,10 @@
 import Phaser from 'phaser';
 
-import { Monster, type MonsterHitbox } from '@game/monster';
+import { Monster, type MonsterHitbox, type MonsterHitboxDefinition } from '@game/monster';
 import { HitboxManager } from '../combat/hitboxManager';
+import { sampleHurtboxRig } from '../combat/hurtbox_rig';
+import { getShapeBounds } from '../combat/shapes';
+import { BRINE_WALKER_HURTBOX_RIG } from '../content/collision/brine_walker';
 
 let idSequence = 0;
 
@@ -20,7 +23,59 @@ export class BrineWalker extends Monster {
   }
 
   syncHitboxes() {
-    const hitboxes = super.getHitboxes();
+    const pose = this.getCurrentPose();
+    const state = this.getCurrentHurtState();
+    const elapsed = this.getHurtStateElapsed();
+    const defs = this.getHitboxDefinitions();
+    const fallbackDef: MonsterHitboxDefinition = defs[0] ?? {
+      id: 'core',
+      part: 'core',
+      damageMultiplier: 1,
+    };
+    let shapes = sampleHurtboxRig(BRINE_WALKER_HURTBOX_RIG, state, elapsed);
+    if (shapes.length === 0) {
+      shapes = sampleHurtboxRig(BRINE_WALKER_HURTBOX_RIG, 'idle', elapsed);
+    }
+    const cos = Math.cos(pose.angle);
+    const sin = Math.sin(pose.angle);
+    const hitboxes: MonsterHitbox[] = shapes.map((shape, index) => {
+      const def = defs[index] ?? fallbackDef;
+      if (shape.kind === 'circle') {
+        const rx = shape.x * cos - shape.y * sin;
+        const ry = shape.x * sin + shape.y * cos;
+        const worldShape = { kind: 'circle' as const, x: pose.x + rx, y: pose.y + ry, r: shape.r };
+        return {
+          id: def.id,
+          part: def.part,
+          shape: worldShape,
+          rect: getShapeBounds(worldShape),
+          damageMultiplier: def.damageMultiplier ?? 1,
+        };
+      }
+      const a = {
+        x: shape.ax * cos - shape.ay * sin,
+        y: shape.ax * sin + shape.ay * cos,
+      };
+      const b = {
+        x: shape.bx * cos - shape.by * sin,
+        y: shape.bx * sin + shape.by * cos,
+      };
+      const worldShape = {
+        kind: 'capsule' as const,
+        ax: pose.x + a.x,
+        ay: pose.y + a.y,
+        bx: pose.x + b.x,
+        by: pose.y + b.y,
+        r: shape.r,
+      };
+      return {
+        id: def.id,
+        part: def.part,
+        shape: worldShape,
+        rect: getShapeBounds(worldShape),
+        damageMultiplier: def.damageMultiplier ?? 1,
+      };
+    });
     this.hitboxManager.registerHurtboxes('monsters', this.hurtboxOwnerId, this.toRegistrations(hitboxes));
   }
 


### PR DESCRIPTION
## Summary
- track hurt state elapsed time and expose pose/state helpers for monsters
- sample the Brine Walker hurtbox rig and register transformed shapes with metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de73a552148332bd0a75796ad9924c